### PR TITLE
Build: Fix gcc compiler scope to work on Linux

### DIFF
--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -35,7 +35,7 @@ QMAKE_CXXFLAGS_DEBUG -= -DNDEBUG
 QMAKE_CFLAGS_DEBUG -= -DNDEBUG
 release {
     CONFIG += optimize_full
-    clang|g++|win32-g++ {
+    clang|*-g++ {
         QMAKE_CXXFLAGS_RELEASE += -fomit-frame-pointer
         QMAKE_CFLAGS_RELEASE += -fomit-frame-pointer
     }


### PR DESCRIPTION
With this `-fomit-frame-pointer` gets picked up on Linux