### PR TITLE
Build: Add Dockerfile based on Ubuntu Bionic + Qt 5.13.2 PPA

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:bionic
+LABEL maintainer="Axel Gembe <derago@gmail.com>"
+
+RUN apt-get update -y && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:beineri/opt-qt-5.12.3-bionic && \
+    apt-get update -y && \
+    apt-get install -y qt512base openssl && \
+    apt-get install -y git build-essential zlib1g-dev libbz2-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    mkdir Fulcrum && cd Fulcrum && git init && \
+    git remote add origin https://github.com/cculianu/Fulcrum.git && \
+    git fetch --depth 1 origin master && \
+    git checkout -b pinned FETCH_HEAD && \
+    /opt/qt512/bin/qmake -makefile Fulcrum.pro && \
+    make install && \
+    apt-get remove -y git build-essential zlib1g-dev libbz2-dev && \
+    apt-get autoremove -y && \
+    rm -rf Fulcrum
+
+ENV PATH=/opt/Fulcrum/bin:$PATH
+
+VOLUME ["/data"]
+ENV DATA_DIR /data
+
+ENV SSL_CERTFILE ${DATA_DIR}/fulcrum.crt
+ENV SSL_KEYFILE ${DATA_DIR}/fulcrum.key
+
+EXPOSE 50001 50002
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["Fulcrum"]

--- a/contrib/docker/docker-entrypoint.sh
+++ b/contrib/docker/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ ! -e "$SSL_CERTFILE" ] || [ ! -e "$SSL_KEYFILE" ] ; then
+  openssl req -newkey rsa:2048 -sha256 -nodes -x509 -days 365 -subj "/O=Fulcrum" -keyout "$SSL_KEYFILE" -out "$SSL_CERTFILE"
+fi
+
+if [ "$1" = "Fulcrum" ] ; then
+  set -- "$@" -D "$DATA_DIR" -c "$SSL_CERTFILE" -k "$SSL_KEYFILE"
+fi
+
+exec "$@"


### PR DESCRIPTION
Docker Hub runs an older version of docker, so we can't use any newer glibc (>= 2.28) that support the statx syscall. Because of this we use Ubuntu Bionic as a base, which ships with version 2.27.

When Docker Hub upgrades to Docker >= 18.04 we can use a newer base.