### PR TITLE
Build: Make Docker build cachable and build from the local repo

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,6 +1,7 @@
-ARG cores=1
 FROM ubuntu:bionic
 LABEL maintainer="Axel Gembe <derago@gmail.com>"
+
+ARG MAKEFLAGS
 
 RUN apt-get update -y && \
     apt-get install -y software-properties-common && \
@@ -15,7 +16,7 @@ RUN apt-get update -y && \
     git fetch --depth 1 origin master && \
     git checkout -b pinned FETCH_HEAD && \
     /opt/qt513/bin/qmake -makefile Fulcrum.pro && \
-    make -j ${cores} install && \
+    make $MAKEFLAGS install && \
     apt-get remove -y git build-essential zlib1g-dev libbz2-dev && \
     apt-get autoremove -y && \
     rm -rf Fulcrum

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -10,16 +10,17 @@ RUN apt-get update -y && \
     apt-get install -y qt513base openssl && \
     apt-get install -y git build-essential zlib1g-dev libbz2-dev && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    mkdir Fulcrum && cd Fulcrum && git init && \
-    git remote add origin https://github.com/cculianu/Fulcrum.git && \
-    git fetch --depth 1 origin master && \
-    git checkout -b pinned FETCH_HEAD && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY . /src
+
+RUN cd /src && \
     /opt/qt513/bin/qmake -makefile Fulcrum.pro && \
-    make $MAKEFLAGS install && \
+    make $MAKEFLAGS install
+
+RUN rm -rf /src && \
     apt-get remove -y git build-essential zlib1g-dev libbz2-dev && \
-    apt-get autoremove -y && \
-    rm -rf Fulcrum
+    apt-get autoremove -y
 
 ENV PATH=/opt/Fulcrum/bin:$PATH
 
@@ -31,7 +32,7 @@ ENV SSL_KEYFILE ${DATA_DIR}/fulcrum.key
 
 EXPOSE 50001 50002
 
-COPY docker-entrypoint.sh /entrypoint.sh
+COPY contrib/docker/docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["Fulcrum"]

--- a/contrib/docker/build.sh
+++ b/contrib/docker/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+if [ -z "$1" ] ; then
+    echo "Usage: $0 <image tag>"
+    exit 1
+fi
+
+IMAGE_TAG="$1"
+
+here=$(dirname $(realpath "$0" 2> /dev/null || grealpath "$0"))
+. "$here"/../base.sh
+
+docker build --build-arg MAKEFLAGS=$WORKER_COUNT -t "$IMAGE_TAG" -f contrib/docker/Dockerfile "$here"/../..


### PR DESCRIPTION
To use, run this in the project root:

```
docker build -t fulcrum-test -f contrib/docker/Dockerfile .
```

Depends on #8 