### PR TITLE
Build: Add proper installation target

### DIFF
--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -223,11 +223,6 @@ HEADERS += robin_hood/robin_hood.h
 RESOURCES += \
     resources.qrc
 
-# Default rules for deployment.
-qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /opt/$${TARGET}/bin
-!isEmpty(target.path): INSTALLS += target
-
 # Bitcoin related sources & headers
 SOURCES += \
     bitcoin/amount.cpp \
@@ -343,3 +338,28 @@ HEADERS += \
     bitcoin/uint256.h \
     bitcoin/utilstrencodings.h \
     bitcoin/version.h
+
+# Installation
+unix:!android: {
+    !defined(PREFIX, var) {
+        PREFIX=$$(PREFIX)
+        isEmpty(PREFIX) {
+            PREFIX = /usr/local
+        }
+    }
+
+    message("Installation dir prefix is $$PREFIX")
+
+    target.path = $${PREFIX}/bin
+
+    documentation.path = $${PREFIX}/share/doc/$${TARGET}
+    documentation.files = doc/*
+
+    QMAKE_STRIP = true # Trick qmake into not stripping files
+    admin.path = $${PREFIX}/bin
+    admin.files = FulcrumAdmin
+}
+
+!isEmpty(target.path): INSTALLS += target
+!isEmpty(documentation.path): INSTALLS += documentation
+!isEmpty(admin.path): INSTALLS += admin


### PR DESCRIPTION
This will install documentation to `$PREFIX/share/doc/$TARGET` and binaries to `$PREFIX/bin`. `$PREFIX` defaults to `/usr/local` and can be overridden from the environment or `qmake` command line.

We need to override `QMAKE_STRIP` for the admin target because `qmake` is calling `strip` on any file with execute bit enabled, which fails for Python files.