### PR TITLE
Implemented blockchain.address.* methods

### DIFF
--- a/src/ServerMisc.cpp
+++ b/src/ServerMisc.cpp
@@ -4,7 +4,7 @@
 namespace ServerMisc
 {
     const Version MinProtocolVersion(1,4,0);
-    const Version MaxProtocolVersion(1,4,2);
+    const Version MaxProtocolVersion(1,4,3);
     const QString AppVersion(VERSION);
     const QString AppSubVersion = QString("%1 %2").arg(APPNAME).arg(VERSION);
 }

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -1094,7 +1094,8 @@ void Server::rpc_blockchain_relayfee(Client *c, const RPC::Message &m)
     emit c->sendResult(m.id, bitcoinDInfo.relayFee);
 }
 
-// ---- These two are used by both the blockchain.scripthash.* and blockchain.address.* sets of methods below for boilerplate checking
+// ---- The below two methods are used by both the blockchain.scripthash.* and blockchain.address.* sets of methods
+//      below for boilerplate checking & parsing.
 HashX Server::parseFirstAddrParamToShCommon(const RPC::Message &m, QString *addrStrOut) const
 {
     const auto net = srvmgr->net();

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -34,6 +34,7 @@
 #include <QVector>
 
 #include <memory> // for shared_ptr
+#include <optional>
 #include <shared_mutex>
 
 struct TcpServerError : public Exception

--- a/src/SrvMgr.cpp
+++ b/src/SrvMgr.cpp
@@ -95,6 +95,8 @@ namespace {
 // throw Exception on error
 void SrvMgr::startServers()
 {
+    _net = BTC::NetFromName(storage->getChain()); // set this now since server instances may need this information
+
     if (options->peerDiscovery) {
         Log() << "SrvMgr: starting PeerMgr ...";
         peermgr = std::make_shared<PeerMgr>(this, storage, options);


### PR DESCRIPTION
This involved some slight refactoring to refactor out the common code
used by both `blockchain.scripthash.*` and `blockchain.address.*`, but
overall it's a very clean implementation.

Note that `blockchain.address.subscribe` will always notify on the exact
string (trimmed) that the client supplied.  This will need to be
documented in the protocol spec.

Also `blockchain.address.unsubscribe` will unsubscribe to the address as it
maps onto a scripthash.  So it's possible to subscribe to an address as cashaddr
and then unsubscribe as legacy (or vice-versa) and the software will do the obvious
thing and unsubscribe from that scripthash.
