### PR TITLE
Default log timestamps are now human-friendly, plus nits and fixups.

### DIFF
--- a/contrib/rpm/fulcrum.spec
+++ b/contrib/rpm/fulcrum.spec
@@ -1,5 +1,5 @@
 Name:    {{{ git_name name="fulcrum" }}}
-Version: 1.1.0
+Version: 1.1.1
 Release: {{{ git_version }}}%{?dist}
 Summary: A fast & nimble SPV server for Bitcoin Cash
 

--- a/doc/fulcrum-example-config.conf
+++ b/doc/fulcrum-example-config.conf
@@ -706,6 +706,15 @@ rpcpassword = hunter1
 #subnets_to_exclude_from_per_ip_limits = 127.0.0.1/32, ::1/128
 
 
+# Log timestamp format - 'ts-format' - DEFAULT: localtime
+#
+# Specify the log timestamp format, one of: none, uptime, localtime, utc. If
+# unspecified, the default is "localtime". Before this option was introduced,
+# previous versions of Fulcrum always logged using "uptime".
+#
+#ts-format = localtime
+#
+
 # Work queue size - 'workqueue' - DEFAULT: 10000
 #
 # The maximum size of the work queue. Requests from clients that require further

--- a/doc/unix-man-page.md
+++ b/doc/unix-man-page.md
@@ -1,6 +1,6 @@
-% FULCRUM(1) Version 1.1.0 | Fulcrum Manual
+% FULCRUM(1) Version 1.1.1 | Fulcrum Manual
 % Fulcrum is written by Calin Culianu (cculianu)
-% April 15, 2020
+% May 13, 2020
 
 # NAME
 
@@ -95,6 +95,9 @@ Once the server finishes synching it will behave like an ElectronX/ElectrumX ser
 
 -T, --polltime <polltime>
 :   The number of seconds for the bitcoind poll interval. Bitcoind is polled once every `polltime` seconds to detect mempool and blockchain changes. This value must be at least 0.5 and cannot exceed 30. If not specified, defaults to 2 seconds.
+
+--ts-format <keyword>
+:   Specify log timestamp format, one of: "none", "uptime", "localtime", or "utc". If unspecified, default is "localtime" (previous versions of Fulcrum always logged using "uptime").
 
 --dump-sh <outputfile>
 :    *This is an advanced debugging option*. Dump script hashes. If specified, after the database is loaded, all of the script hashes in the database will be written to outputfile as a JSON array.

--- a/src/BTC_Address.cpp
+++ b/src/BTC_Address.cpp
@@ -118,7 +118,7 @@ namespace BTC
             if (dec.size() != 21) {
                 // this should never happen
 #ifdef QT_DEBUG
-                Debug() << __FUNCTION__ << ": bad decoded length  " << dec.size() << " for address " << legacyOrCash;
+                DebugM(__func__, ": bad decoded length  ", dec.size(), " for address ", legacyOrCash);
 #endif
             } else {
                 a.verByte = dec[0];
@@ -133,7 +133,7 @@ namespace BTC
             try {
                 if (!(ok = DecodeCash(a, ss))) {
 #ifdef QT_DEBUG
-                    Debug() << __FUNCTION__ << ": got bad address " << legacyOrCash;
+                    DebugM(__func__, ": got bad address ", legacyOrCash);
 #endif
                 }
             } catch (const std::exception &e) {

--- a/src/Common.h
+++ b/src/Common.h
@@ -38,7 +38,7 @@ struct InternalError : public Exception { using Exception::Exception; };
 struct BadArgs : public Exception { using Exception::Exception; };
 
 #define APPNAME "Fulcrum"
-#define VERSION "1.1.0"
+#define VERSION "1.1.1"
 #ifdef QT_DEBUG
 #  define VERSION_EXTRA "(Debug)"
 inline constexpr bool isReleaseBuild() { return false; }

--- a/src/Merkle.cpp
+++ b/src/Merkle.cpp
@@ -30,13 +30,13 @@ namespace Merkle {
         const unsigned hvsz = unsigned(hashVec.size());
         if (!hvsz || index >= hvsz) {
             Error() << __PRETTY_FUNCTION__ << ": Misused. Please specify a non-empty hash vector as well as an in-range index. FIXME!";
-            throw BadArgs(QString("Bad args to %1").arg(__FUNCTION__));
+            throw BadArgs(QString("Bad args to %1").arg(__func__));
         }
         const unsigned natLen = branchLength(unsigned(hvsz));
         const unsigned length = optLen.value_or(natLen);
         if (length < natLen) {
             Error() << __PRETTY_FUNCTION__ << ": Misused. Must specify a length argument that is >= " << natLen << " for a vector of size " << hvsz << ". FIXME!";
-            throw BadArgs(QString("Bad length arg to %1").arg(__FUNCTION__));
+            throw BadArgs(QString("Bad length arg to %1").arg(__func__));
         }
         HashVec branch;
         branch.reserve(length);
@@ -66,7 +66,7 @@ namespace Merkle {
         }
         if (UNLIKELY(hashes.empty())) {
             Error() << __PRETTY_FUNCTION__ << ": INTERNAL ERROR. Output vector is empty! FIXME!";
-            throw InternalError(QString("%1: Output hash vector is empty").arg(__FUNCTION__));
+            throw InternalError(QString("%1: Output hash vector is empty").arg(__func__));
         }
         ret = { std::move(branch), hashes.front() };
         return ret;
@@ -84,7 +84,7 @@ namespace Merkle {
         }
         if (index) {
             Error() << __PRETTY_FUNCTION__ << ": INTERNAL ERROR. Passed-in index is out of range! FIXME!";
-            throw BadArgs(QString("%1: Index argument out of range").arg(__FUNCTION__));
+            throw BadArgs(QString("%1: Index argument out of range").arg(__func__));
         }
         return hash;
     }
@@ -116,7 +116,7 @@ namespace Merkle {
         BranchAndRootPair ret;
         if (level.empty() || leafHashes.empty() || depthHigher > MaxDepth) {
             Error() << __PRETTY_FUNCTION__ << ": Invalid args";
-            throw BadArgs(QString("Invalid arguments to %1").arg(__FUNCTION__));
+            throw BadArgs(QString("Invalid arguments to %1").arg(__func__));
         }
         const unsigned leafIndex = (index >> depthHigher) << depthHigher; // funny way to make 0's on the right.
         auto leafPair = branchAndRoot(leafHashes, index - leafIndex, depthHigher);
@@ -126,7 +126,7 @@ namespace Merkle {
         const auto & [levelBranch, root] = levelPair;
         if (index >= level.size() || leafRoot != level[index]) {
             Error() << __PRETTY_FUNCTION__ << ": leaf hashes inconsistent with level. FIXME!";
-            throw InternalError(QString("%1: leaf hashes inconsistent with level").arg(__FUNCTION__));
+            throw InternalError(QString("%1: leaf hashes inconsistent with level").arg(__func__));
         }
         auto & outVec (leafBranch); // we concatenate to the end of this vector
         outVec.reserve(outVec.size() + levelBranch.size()); // make room
@@ -212,7 +212,7 @@ namespace Merkle {
         depthHigher = Merkle::treeDepth(length) / 2;
         level = getLevel(hashes);
         initialized = true;
-        Debug() << "Merkle cache initialized to length " << length;
+        DebugM("Merkle cache initialized to length ", length);
     }
 
     HashVec Cache::getLevel(const HashVec &hashes) const {
@@ -235,7 +235,7 @@ namespace Merkle {
         level.reserve(level.size() + vec.size());
         level.insert(level.end(), vec.begin(), vec.end());
         length = l;
-        Debug() << "Merkle cache extended to length " << length;
+        DebugM("Merkle cache extended to length ", length);
     }
 
     HashVec Cache::levelFor(unsigned l) const
@@ -264,17 +264,17 @@ namespace Merkle {
     BranchAndRootPair Cache::branchAndRoot(unsigned length, unsigned index)
     {
         if (!length)
-            throw BadArgs(QString("%1: length must not be 0").arg(__FUNCTION__));
+            throw BadArgs(QString("%1: length must not be 0").arg(__func__));
         if (index >= length)
-            throw BadArgs(QString("%1: index must be less than length").arg(__FUNCTION__));
+            throw BadArgs(QString("%1: index must be less than length").arg(__func__));
         if (!initialized)
-            throw InternalError(QString("%1: Merkle cache is not initialized").arg(__FUNCTION__));
+            throw InternalError(QString("%1: Merkle cache is not initialized").arg(__func__));
         BranchAndRootPair ret;
         ExclusiveLockGuard g(lock);
         extendTo(length);
         if (length > this->length) {
             // ruh-roh.. what to do here?
-            throw InternalError(QString("%1: extendTo failed to extend length to %2").arg(__FUNCTION__).arg(length));
+            throw InternalError(QString("%1: extendTo failed to extend length to %2").arg(__func__).arg(length));
         }
         auto ls = leafStart(index);
         auto count = std::min(segmentLength(), length - ls);
@@ -293,7 +293,7 @@ namespace Merkle {
         if (!initialized)
             return;
         if (!length)
-            throw BadArgs(QString("%1: length cannot be 0").arg(__FUNCTION__));
+            throw BadArgs(QString("%1: length cannot be 0").arg(__func__));
         ExclusiveLockGuard g(lock);
         if (this->length <= length)
             // we are already smaller than length, so it's fine.
@@ -306,7 +306,7 @@ namespace Merkle {
             Warning() << "limit > levelSize in merkle cache truncate. FIXME!";
         }
         level.erase(level.begin()+limit, level.end());
-        Debug() << "Merkle cache truncated to length " << length;
+        DebugM("Merkle cache truncated to length ", length);
     }
 
 

--- a/src/Mixins.cpp
+++ b/src/Mixins.cpp
@@ -49,7 +49,7 @@ bool ThreadObjectMixin::isLifecyclePrint() const
 void ThreadObjectMixin::start()
 {
     if (_thread.isRunning())  return;
-    if (isLifecyclePrint()) Debug() << qobj()->objectName() << " starting thread";
+    if (isLifecyclePrint()) DebugM(qobj()->objectName(), " starting thread");
     chan.clear();
     origThread = qobj()->thread();
     conns += origThread->connect(origThread, &QThread::finished, qobj(), [this, qo=qobj(), which=conns.size()] {
@@ -67,7 +67,7 @@ void ThreadObjectMixin::stop()
 {
     const bool dbgLC = isLifecyclePrint();
     if (_thread.isRunning()) {
-        if (dbgLC) Debug() << _thread.objectName() << " thread is running, joining thread";
+        if (dbgLC) DebugM(_thread.objectName(), " thread is running, joining thread");
         _thread.quit();
         _thread.wait();
     }
@@ -77,7 +77,7 @@ void ThreadObjectMixin::stop()
         ++ct;
     }
     conns.clear();
-    if (ct && dbgLC) Debug() << _thread.objectName() << " cleaned up " << ct << " signal/slot connections";
+    if (ct && dbgLC) DebugM(_thread.objectName(), " cleaned up ", ct, " signal/slot connections");
 }
 
 
@@ -126,7 +126,7 @@ void TimersByNameMixin::callOnTimerSoon(int ms, const QString &name, const std::
     _timerMap[name] = timer;
     timer->setObjectName(name);
     timer->start(ms);
-    //Debug() << "timerByName: " << name << " started, ms = " << ms;
+    //DebugM("timerByName: ", name, " started, ms = ", ms);
 }
 
 /// Identical to above, except takes a pure voidfunc. It's as if the above returned false (so will not keep going).
@@ -168,7 +168,7 @@ auto StatsMixin::statsSafe(int timeout_ms) const -> Stats
     try {
         ret = Util::LambdaOnObject<Stats>(qobj(), [this]{ return stats(); }, timeout_ms);
     } catch (const std::exception & e) {
-        Debug() << "Safe stats get failed: " << e.what();
+        DebugM("Safe stats get failed: ",  e.what());
         ret = QVariantMap{{"error" , e.what()}};
     }
     return ret;
@@ -181,7 +181,7 @@ auto StatsMixin::debugSafe(const StatsParams &p, int timeout_ms) const -> Stats
     try {
         ret = Util::LambdaOnObject<Stats>(qobj(), [this, p]{ return debug(p); }, timeout_ms);
     } catch (const std::exception & e) {
-        Debug() << "Safe debug get failed: " << e.what();
+        DebugM("Safe debug get failed: ", e.what());
         ret = QVariantMap{{"error" , e.what()}};
     }
     return ret;

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -140,7 +140,21 @@ QVariantMap Options::toMap() const
     // db advanced options
     m["db_max_open_files"] = qlonglong(db.maxOpenFiles);
     m["db_keep_log_file_num"] = qlonglong(db.keepLogFileNum);
+    // ts-format
+    m["ts-format"] = logTimestampModeString();
     return m;
+}
+
+QString Options::logTimestampModeString() const
+{
+    switch (logTimestampMode) {
+    // NB: We didn't use QStringLiteral here since this is called rarely so we are better off embedding C-strings
+    // in the compiled binary rather than the wide strings that QStringLiteral embeds in the compiled code.
+    case LogTimestampMode::None: return "none";
+    case LogTimestampMode::Local: return "localtime";
+    case LogTimestampMode::Uptime: return "uptime";
+    case LogTimestampMode::UTC: return "utc";
+    }
 }
 
 bool Options::BdReqThrottleParams::isValid() const noexcept

--- a/src/Options.h
+++ b/src/Options.h
@@ -54,7 +54,7 @@ public:
         false; ///< gets set to false on release builds
 #endif
     std::atomic_bool verboseTrace = false; ///< this gets set if -d -d specified
-    std::atomic_bool syslogMode = false; ///< if true, suppress printing of timestamps to logger
+    std::atomic_bool syslogMode = false; ///< if true, suppress printing of timestamps to logger by default (may be overridden with --ts-format)
 
     bool hasIPv6Listener = false; ///< used internally -- set to true by argParser if at least one of the specified listening interfaces is IPv6, false otherwise
 
@@ -192,6 +192,13 @@ public:
         static constexpr bool isKeepLogFileNumInBounds(int64_t k) { return k >= int64_t(minKeepLogFileNum) && k <= int64_t(maxKeepLogFileNum); }
     };
     DBOpts db;
+
+    enum class LogTimestampMode {
+        None = 0, Uptime, Local, UTC
+    };
+    static constexpr auto defaultLogTimeStampMode = LogTimestampMode::Local;
+    LogTimestampMode logTimestampMode = defaultLogTimeStampMode;
+    QString logTimestampModeString() const;
 };
 
 /// A class encapsulating a simple read-only config file format.  The format is similar to the bitcoin.conf format

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -255,7 +255,7 @@ namespace {
                 }
             } else {
                 if (UNLIKELY(acceptExtraBytesAtEndOfData))
-                    Debug() << "Warning:  Caller misuse of function '" << __FUNCTION__
+                    Debug() << "Warning:  Caller misuse of function '" << __func__
                             << "'. 'acceptExtraBytesAtEndOfData=true' is ignored when deserializing using QDataStream.";
                 bool ok;
                 ret.emplace( Deserialize<RetType>(FromSlice(datum), &ok) );
@@ -796,7 +796,7 @@ void Storage::saveMeta_impl()
         throw DatabaseError("Failed to write meta to db");
     }
 
-    Debug() << "Wrote new metadata to db";
+    DebugM("Wrote new metadata to db");
 }
 
 void Storage::appendHeader(const Header &h, BlockHeight height)
@@ -955,7 +955,7 @@ void Storage::loadCheckTxNumsFileAndBlkInfo()
 // NOTE: this must be called *after* loadCheckTxNumsFileAndBlkInfo(), because it needs a valid p->txNumNext
 void Storage::loadCheckUTXOsInDB()
 {
-    FatalAssert(!!p->db.utxoset) << __FUNCTION__ << ": Utxo set db is not open";
+    FatalAssert(!!p->db.utxoset, __func__, ": Utxo set db is not open");
 
     if (options->doSlowDbChecks) {
         Log() << "CheckDB: Verifying utxo set (this may take some time) ...";
@@ -1035,7 +1035,7 @@ void Storage::loadCheckUTXOsInDB()
 
 void Storage::loadCheckEarliestUndo()
 {
-    FatalAssert(!!p->db.undo) << __FUNCTION__ << ": Undo db is not open";
+    FatalAssert(!!p->db.undo,  __func__, ": Undo db is not open");
 
     const auto t0 = Util::getTimeNS();
     int ctr = 0;
@@ -1395,7 +1395,7 @@ void Storage::addBlock(PreProcessedBlockPtr ppb, bool saveUndo, unsigned nReserv
                 bool ok;
                 auto undo2 = Deserialize<UndoInfo>(ba, &ok);
                 ba.fill('z'); // ensure no shallow copies of buffer exist in deserialized object. if they do below tests will fail
-                FatalAssert(ok && undo2.isValid()) << "Deser of undo info failed!";
+                FatalAssert(ok && undo2.isValid(), "Deser of undo info failed!");
                 Debug() << "Undo info 2: " << undo2.toDebugString();
                 Debug() << "Undo info 1 == undo info 2: " << (*undo == undo2);
             } else {

--- a/src/SubsMgr.cpp
+++ b/src/SubsMgr.cpp
@@ -184,14 +184,15 @@ void SubsMgr::doNotifyAllPending()
         if (doemit) {
             const auto nClients = sub->subscribedClientIds.size();
             ctr += nClients;
-            Debug() << "Notifying " << nClients << Util::Pluralize(" client", nClients) << " of status for " << Util::ToHexFast(sh);
+            DebugM("Notifying ", nClients, Util::Pluralize(" client", nClients), " of status for ", Util::ToHexFast(sh));
             sub->updateTS();
             emit sub->statusChanged(sh, status);
         }
     }
     if (ctr || ctrSH) {
         const auto elapsedMS = (Util::getTimeNS() - t0)/1e6;
-        Debug() << __func__ << ": " << ctr << Util::Pluralize(" client", ctr) << ", " << ctrSH << Util::Pluralize(" scripthash", ctrSH) << " in " << QString::number(elapsedMS, 'f', 4) << " msec";
+        DebugM(__func__, ": ", ctr, Util::Pluralize(" client", ctr), ", ", ctrSH, Util::Pluralize(" scripthash", ctrSH),
+               " in ", QString::number(elapsedMS, 'f', 4), " msec");
     }
 }
 
@@ -332,9 +333,7 @@ bool SubsMgr::unsubscribe(RPC::ConnectionBase *c, const HashX &sh)
             sub->subscribedClientIds.erase(it);
             sub->updateTS();
             bool res = QObject::disconnect(sub.get(), &Subscription::statusChanged, c, nullptr);
-            //Trace() << "Unsub: disconnected signal1 " << (res ? "ok" : "not ok!");
             res = QObject::disconnect(c, &QObject::destroyed, sub.get(), nullptr);
-            //Trace() << "Unsub: disconnected signal2 " << (res ? "ok" : "not ok!");
             ret = true;
             --p->nClientSubsActive;
         }
@@ -379,7 +378,7 @@ auto SubsMgr::getFullStatus(const HashX &sh) const -> StatusHash
     const auto elapsed = Util::getTimeNS() - t0;
     constexpr qint64 kTookKindaLongNS = 7500000LL; // 7.5mec -- if it takes longer than this, log it to debug log, otherwise don't as this can get spammy.
     if (elapsed > kTookKindaLongNS) {
-        Debug() << "full status for " << Util::ToHexFast(sh) << " " << hist.size() << " items in " << QString::number(elapsed/1e6, 'f', 4) << " msec";
+        DebugM("full status for ",  Util::ToHexFast(sh), " ", hist.size(), " items in ", QString::number(elapsed/1e6, 'f', 4), " msec");
     }
     return ret;
 }
@@ -407,8 +406,8 @@ void SubsMgr::removeZombies(bool forced)
     if (ctr) {
         p->subs.reserve(p->kSubsReserveSize); // shrink_to_fit if over kSubsReserveSize
         const auto elapsed = Util::getTimeNS() - t0;
-        Debug() << "SubsMgr: Removed " << ctr << " zombie " << Util::Pluralize("sub", ctr) << " out of " << total
-                << " in " << QString::number(elapsed/1e6, 'f', 4) << " msec";
+        DebugM( "SubsMgr: Removed ", ctr, " zombie ", Util::Pluralize("sub", ctr), " out of ", total,
+                " in ", QString::number(elapsed/1e6, 'f', 4), " msec");
     }
 }
 

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -58,7 +58,7 @@ void Job::run() {
     } else if (UNLIKELY(!weakContextRef)) {
         // this is here so we avoid doing any work in case work is costly when we know for a fact the
         // interested/subscribed context object is already deleted.
-        Debug() << objectName() << ": context already deleted, exiting early without doing any work";
+        DebugM(objectName(), ": context already deleted, exiting early without doing any work");
         return;
     }
     if (LIKELY(work)) {
@@ -78,7 +78,7 @@ void Job::run() {
 void ThreadPool::submitWork(QObject *context, const VoidFunc & work, const VoidFunc & completion, const FailFunc & fail, int priority)
 {
     if (blockNewWork) {
-        Debug() << __FUNCTION__ << ": Ignoring new work submitted because blockNewWork = true";
+        Debug() << __func__ << ": Ignoring new work submitted because blockNewWork = true";
         return;
     }
     static const FailFunc defaultFail = [](const QString &msg) {
@@ -123,7 +123,7 @@ bool ThreadPool::shutdownWaitForJobs(int timeout_ms)
 {
     blockNewWork = true;
     if constexpr (debugPrt) {
-        Debug() << __FUNCTION__ << ": waiting for jobs ...";
+        Debug() << __func__ << ": waiting for jobs ...";
     }
     pool->clear();
     return pool->waitForDone(timeout_ms);

--- a/src/bitcoin/cashaddrenc.cpp
+++ b/src/bitcoin/cashaddrenc.cpp
@@ -113,7 +113,7 @@ std::string EncodeCashAddr(const CTxDestination &dst,
         ret = std::visit(CashAddrEncoder(params), dst); // cheap rvalue ref copy assign
     } catch (const std::bad_variant_access & e) {
 #ifdef USE_QT_IN_BITCOIN
-        qCritical("%s: Caught exception bad_variant_access: %s", __FUNCTION__, e.what());
+        qCritical("%s: Caught exception bad_variant_access: %s", __func__, e.what());
 #endif
         // ignore..
         ret.clear();

--- a/src/bitcoin/script_standard.cpp
+++ b/src/bitcoin/script_standard.cpp
@@ -290,7 +290,7 @@ CScript GetScriptForDestination(const CTxDestination &dest) {
     } catch (const std::bad_variant_access &e) {
         // what to do here?
 #ifdef USE_QT_IN_BITCOIN
-        qCritical("%s: Caught exception bad_variant_access: %s", __FUNCTION__, e.what());
+        qCritical("%s: Caught exception bad_variant_access: %s", __func__, e.what());
 #endif
         script.clear();
     }


### PR DESCRIPTION
- Log timestamps now default to localtime [yyy-mm-dd hh:mm:ss.zzz]. The
old behavior (abs time since program start) can be enabled using the new
--ts-format uptime CLI (and conf) argument.

- Log timestamps now default to "none" (no timestamp) if running in syslog
mode (-S).

- Added --ts-format and ts-format= CLI/conf arg for controlling the log
timestamp format.  Log timestamps can be suppressed altogether with
--ts-foramt none

- Bumped version to v1.1.1

- Updated documentation: man page as well as sample conf to describe
this new --ts-format/ts-format= CLI/conf variable.

- Made Debug() and Trace() logging more efficient by not evaluating the
arguments in the common !Debug::isEnabled() or !Trace::isEnabled() case.
We had to resort to using a C-style macro to accomplish this.

- Replaced most uses of `__FUNCTION__` in the codebase with the more
C++-ey `__func__`.

- Various other small nits and fixups.  Overall the app should eat
slightly fewer cycles since all the verbose logging are now no-ops in
the common case (before we were building strings only to throw them away
later).