### PR TITLE
Added bchd support plus various refactorings and bugfixes

### DIFF
--- a/src/BTC.h
+++ b/src/BTC.h
@@ -193,5 +193,9 @@ namespace BTC
     /// Given a network name e.g. "main" or "test", returns the Net enum value, or Net::Invalid if parameter `name` is
     /// not recognized.
     Net NetFromName(const QString & name) noexcept;
+    /// Given a network name e.g. "mainnet" or "test" or "main" or "testnet3" -> transform it to the canonical name
+    /// (such as "main", "test").  This is so that our app uses a single consistent string name for all net names
+    /// as reported by the Bitcoin daemon (bchd uses different net names than bitcoind).
+    inline const QString & NetNameMakeCanonical(const QString &name) noexcept { return NetName(NetFromName(name)); }
 
 } // end namespace

--- a/src/BitcoinD.cpp
+++ b/src/BitcoinD.cpp
@@ -17,6 +17,7 @@
 // <https://www.gnu.org/licenses/>.
 //
 #include <QHostInfo>
+#include <QMetaType>
 #include <QPointer>
 
 #include "bitcoin/rpc/protocol.h"
@@ -100,7 +101,7 @@ void BitcoinDMgr::on_Message(quint64 bid, const RPC::Message &msg)
 }
 void BitcoinDMgr::on_ErrorMessage(quint64 bid, const RPC::Message &msg)
 {
-    DebugM("ErrMsg from: ", bid, " (reqId: ", msg.id, ") error=", msg.errorMessage());
+    DebugM("ErrMsg from: ", bid, " (reqId: ", msg.id, ", method: ", msg.method, ") error=", msg.errorMessage());
     if (msg.errorCode() == bitcoin::RPCErrorCode::RPC_IN_WARMUP) {
         emit inWarmUp(msg.errorMessage());
     }
@@ -121,6 +122,14 @@ auto BitcoinDMgr::stats() const -> Stats
     m["rpc clients"] = l;
     m["extant request contexts"] = BitcoinDMgrHelper::ReqCtxObj::extant.load();
     m["activeTimers"] = activeTimerMapForStats();
+
+    // "quirks"
+    QVariantMap quirks;
+    quirks["bchd"] = this->quirks.isBchd.load();
+    quirks["bchdGetRawTransaction"] = this->quirks.isBchd && this->quirks.bchdGetRawTransaction;
+    quirks["zeroArgEstimateFee"] = this->quirks.zeroArgEstimateFee.load();
+    m["quirks"] = quirks;
+
     return m;
 }
 
@@ -144,10 +153,70 @@ BitcoinD *BitcoinDMgr::getBitcoinD()
     return ret;
 }
 
+void BitcoinDMgr::setBitcoinDVersion(const Version &version, const QString &subversion)
+{
+    // bchd?
+    quirks.isBchd = subversion.startsWith("/bchd"); // informs submitRequest that we (maybe) need to do some workarounds for bchd
+
+    // requires 0 arg `estimatefee`?
+    static const auto isZeroArgEstimateFee = [](const Version &version, const QString &subversion) -> bool {
+        static const QString zeroArgSubversionPrefixes[] = { "/Bitcoin ABC", "/Bitcoin Cash Node", };
+        static const Version minVersion{0, 20, 2};
+        if (version < minVersion)
+            return false;
+        for (const auto & prefix : zeroArgSubversionPrefixes)
+            if (subversion.startsWith(prefix))
+                return true;
+        return false;
+    };
+    quirks.zeroArgEstimateFee = isZeroArgEstimateFee(version, subversion);
+}
+
+QVariantList BitcoinDMgr::applyBitcoinDQuirksToParams(const BitcoinDMgrHelper::ReqCtxObj *context, const QString &method, const QVariantList &paramsIn)
+{
+    QVariantList params{paramsIn}; // quick shallow copy
+    // bchd quirk workaround detection (may add custom error handler connected to `this`, and mutate params iff `getrawtransaction`)
+    if (quirks.isBchd.load(std::memory_order::memory_order_relaxed)) {
+        if (method == QStringLiteral("getrawtransaction")) {
+            // first, unconditionally attach this error handler (runs via DIRECT CONNECTION in `context`'s thread)
+            connect(context, &BitcoinDMgrHelper::ReqCtxObj::error, this, [quirks=&quirks](const RPC::Message &response) {
+                // Note: for performance, this runs in the `context` object's thread as a direct conenction
+                // and as such it only captures a pointer to the thread-safe object "quirks"
+                DebugM("BitcoinDMgr: bchd-quirk error handler fired for `", response.method, "`");
+                if (response.errorCode() == -8) {
+                    const bool flagVal = quirks->bchdGetRawTransaction;
+                    if (!flagVal && response.errorMessage().contains("must be type int")) {
+                        // bug present -- enable flag
+                        quirks->bchdGetRawTransaction = true;
+                        DebugM("BitcoinDMgr: latched quirk flag `bchdGetRawTransaction` to true");
+                    } else if (flagVal && response.errorMessage().contains("must be type bool")) {
+                        // bug was fixed in a future version -- disable flag
+                        quirks->bchdGetRawTransaction = false;
+                        DebugM("BitcoinDMgr: latched quirk flag `bchdGetRawTransaction` to false");
+                    }
+                }
+            }, Qt::DirectConnection);
+            // next, possibly do the `getrawtransaction` parameter transform if flag is set
+            if (quirks.bchdGetRawTransaction && params.size() >= 2) {
+                // transform the second arg to int from bool to handle bchd quirks
+                if (auto var = params[1]; QMetaType::Type(var.type()) == QMetaType::Type::Bool) {
+                    var = int(var.toBool());
+                    params[1] = var;
+                }
+            }
+        }
+    }
+    // BCHN or ABC >= v.0.20.6 require no arguments to "estimatefee"
+    if (quirks.zeroArgEstimateFee.load(std::memory_order::memory_order_relaxed) && method == QStringLiteral("estimatefee")) {
+        params.clear();
+    }
+    return params;
+}
+
 /// This is safe to call from any thread. Internally it dispatches messages to this obejct's thread.
 /// Does not throw. Results/Error/Fail functions are called in the context of the `sender` thread.
 /// Returns the BitcoinD->id that was given the message.
-void BitcoinDMgr::submitRequest(QObject *sender, const RPC::Message::Id &rid, const QString & method, const QVariantList & params,
+void BitcoinDMgr::submitRequest(QObject *sender, const RPC::Message::Id &rid, const QString & method, const QVariantList & paramsIn,
                                 const ResultsF & resf, const ErrorF & errf, const FailF & failf)
 {
     using namespace BitcoinDMgrHelper;
@@ -163,21 +232,30 @@ void BitcoinDMgr::submitRequest(QObject *sender, const RPC::Message::Id &rid, co
         context->deleteLater();
     });
     context->setObjectName(QStringLiteral("context for '%1' request id: %2").arg(sender ? sender->objectName() : QString()).arg(rid.toString()));
+
+    // first, apply any bitcoind quirks (transforms 'params', may attach additional error handlers, etc)
+    const QVariantList params = applyBitcoinDQuirksToParams(context.get(), method, paramsIn);
+
+    // result handler (runs in sender thread)
     connect(context.get(), &ReqCtxObj::results, sender, [context, resf](const RPC::Message &response) {
         if (!context->replied.exchange(true) && resf)
             resf(response);
         context->disconnect(); // kills all lambdas and shared ptr, should cause deleter to execute
     });
+    // error handler (runs in sender thread)
     connect(context.get(), &ReqCtxObj::error, sender, [context, errf](const RPC::Message &response) {
         if (!context->replied.exchange(true) && errf)
             errf(response);
         context->disconnect(); // kills all lambdas and shared ptr, should cause deleter to execute
     });
+    // failure handler (runs in sender thread)
     connect(context.get(), &ReqCtxObj::fail, sender, [context, failf](const RPC::Message::Id &origId, const QString & failureReason) {
         if (!context->replied.exchange(true) && failf)
             failf(origId, failureReason);
         context->disconnect(); // kills all lambdas and shared ptr, should cause deleter to execute
     });
+
+    // send the context to our thread
     context->moveToThread(this->thread());
 
     // schedule this ASAP

--- a/src/BitcoinD.cpp
+++ b/src/BitcoinD.cpp
@@ -100,7 +100,7 @@ void BitcoinDMgr::on_Message(quint64 bid, const RPC::Message &msg)
 }
 void BitcoinDMgr::on_ErrorMessage(quint64 bid, const RPC::Message &msg)
 {
-    DebugM("ErrMsg from: ", bid, " (reqId: ", msg.id.toString(),") error=", msg.errorMessage());
+    DebugM("ErrMsg from: ", bid, " (reqId: ", msg.id, ") error=", msg.errorMessage());
     if (msg.errorCode() == bitcoin::RPCErrorCode::RPC_IN_WARMUP) {
         emit inWarmUp(msg.errorMessage());
     }

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -232,8 +232,11 @@ void GetChainInfoTask::process()
 
             if (auto v = map.value("initialblockdownload"); v.canConvert<bool>())
                 info.initialBlockDownload = v.toBool();
-            else
-                Err("initialblockdownload");
+            else {
+                //Err("initialblockdownload");
+                // tolerate missing initialblockdownload key since bchd doesn't emit this key
+                info.initialBlockDownload = false;
+            }
 
             info.chainWork = Util::ParseHexFast(map.value("chainwork").toByteArray()); // error ok
             info.sizeOnDisk = map.value("size_on_disk").toULongLong(); // error ok
@@ -1251,7 +1254,7 @@ void CtlTask::on_error(const RPC::Message &resp)
 }
 void CtlTask::on_failure(const RPC::Message::Id &id, const QString &msg)
 {
-    Warning() << id.toString() << ": FAIL: " << msg;
+    Warning() << id << ": FAIL: " << msg;
     errorCode = id.toInt();
     errorMessage = msg;
     emit errored();

--- a/src/PeerMgr.cpp
+++ b/src/PeerMgr.cpp
@@ -31,6 +31,7 @@
 #include <QSslConfiguration>
 #include <QSslSocket>
 #include <QTcpSocket>
+#include <QVector>
 
 #include <list>
 #include <utility>
@@ -77,10 +78,11 @@ void PeerMgr::startup()
     if (_genesisHash.length() != HashLen)
         throw InternalError("PeerMgr cannot be started until we have a valid genesis hash! FIXME!");
 
-    if (const auto chain = storage->getChain(); !QSet<QString>{"test", "main"}.contains(chain))
+    const auto chain = storage->getChain();
+    if (const auto net = BTC::NetFromName(chain); !QVector<BTC::Net>{{BTC::Net::TestNet, BTC::Net::MainNet}}.contains(net))
         // can only do peering with testnet or mainnet after they have been defined (no regtest)
         throw InternalError(QString("PeerMgr cannot be started for the given chain \"%1\"").arg(chain));
-    else if (chain == "test")
+    else if (net == BTC::Net::TestNet)
         parseServersDotJson(":resources/servers_testnet.json");
     else
         parseServersDotJson(":resources/servers.json");

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -411,7 +411,11 @@ namespace RPC {
             if (message.isError()) {
                 // error message
                 ++nErrorReplies;
-                idMethodMap.remove(message.id); // don't leak the request -- an error response is an answer! Remove from map.
+                // don't leak the request -- an error response is an answer! Remove from map.
+                message.method = idMethodMap.take(message.id);
+                if (!message.id.isNull() && message.method.isEmpty())
+                    // Hmm. Error with no corresponding request id.. log that fact to debug log
+                    DebugM("Got unexpected error reply for id: ", message.id);
                 emit gotErrorMessage(id, message);
             } else if (message.isNotif()) {
                 try {

--- a/src/RPCMsgId.h
+++ b/src/RPCMsgId.h
@@ -124,3 +124,9 @@ inline uint qHash(const RPCMsgId &r, uint seed = 0)  {
     case RPCMsgId::Null: return 0;
     }
 }
+
+/// overload to support writing RpcMsgId to a text stream
+inline QTextStream &operator<<(QTextStream &ts, const RPCMsgId &rid)
+{
+    return ts << rid.toString();
+}

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -212,8 +212,6 @@ protected slots:
     void onErrorMessage(IdMixin::Id clientId, const RPC::Message &m);
     void onPeerError(IdMixin::Id clientId, const QString &what);
 
-    void refreshBitcoinDNetworkInfo(); ///< whenever bitcoind comes back alive, this is invoked to update the BitcoinDInfo struct declared above
-
 protected:
     /// Overrides QTcpServer -- identical to default impl. from QTcpServer except it also attaches a child
     /// Client::PerIPDataHolder_Temp object named "__PerIPDataHolder_Temp" to the QTcpSocket that it creates, and
@@ -244,7 +242,6 @@ protected:
     ///
     // /end `incomingConnection` Helpers
 
-    void on_started() override;
     void on_newConnection(QTcpSocket *) override;
 
     Client * newClient(QTcpSocket *);
@@ -294,15 +291,6 @@ protected:
     const std::shared_ptr<Storage> storage;
     /// pointer to shared BitcoinDMgr object -- owned and controlled by the Controller instance
     const std::shared_ptr<BitcoinDMgr> bitcoindmgr;
-
-    /// This basically all comes from getnetworkinfo to bitcoind.
-    struct BitcoinDInfo {
-        Version version {0,0,0}; ///> major, minor, revision e.g. {0, 20, 6} for v0.20.6
-        QString subversion; ///< subversion string from daemon e.g.: /Bitcoin Cash Node bla bla;EB32 ..../
-        double relayFee = 0.0; ///< from 'relayfee' in the getnetworkinfo response; minimum fee/kb to relay a tx, usually: 0.00001000
-        QString warnings = ""; ///< from 'warnings' in the getnetworkinfo response (usually is empty string, but may not always be)
-    };
-    BitcoinDInfo bitcoinDInfo;
 
     PeerInfoList peers;
 

--- a/src/Version.cpp
+++ b/src/Version.cpp
@@ -11,16 +11,29 @@
 #endif
 
 
-Version::Version(unsigned val, CompactType)
+Version::Version(unsigned val, CompactType type)
 {
-    // e.g. 0.20.6 comes in like this from bitcoind (as an unsigned int): 200600
-    const unsigned major = val / 1000000,
-                   minor0 = val % 1000000,
-                   minor = minor0 / 10000,
-                   revision = (minor0 % 10000) / 100;
-    *this = Version(major, minor, revision);
+    switch(type) {
+    case BitcoinD: {
+        // e.g. 0.20.6 comes in like this from bitcoind (as an unsigned int): 200600
+        const unsigned major = val / 1000000,
+                       minor0 = val % 1000000,
+                       minor = minor0 / 10000,
+                       revision = (minor0 % 10000) / 100;
+        *this = Version(major, minor, revision);
+        break;
+    }
+    case BCHD: {
+        // from bchd sources: version = 2 ^ AppMajor*3 ^ AppMinor*5 ^ AppPatch
+        // I don't understand that code. So we kind of hack it and this mostly works.
+        const unsigned v = val ^ 2; // undo the first 2 ^
+        const unsigned patch   = (v & 0x0f) >> 0;
+        const unsigned minor   = (((v & 0xf0) >> 4) ^ patch) * 16;
+        *this = Version(0, minor, patch);
+        break;
+    }
+    }
 }
-
 
 Version::Version(unsigned maj, unsigned min, unsigned rev)
     : major(maj), minor(min), revision(rev)

--- a/src/Version.h
+++ b/src/Version.h
@@ -45,7 +45,7 @@ struct Version
 
     Version(unsigned maj, unsigned min, unsigned rev);
 
-    enum CompactType { BitcoinD };
+    enum CompactType { BitcoinD, BCHD };
     /// To explicitly construct an instance from the version number returned by bitcoind's getnetworkinfo RPC call
     /// e.g.: 200600 becomes -> 0.20.6
     explicit Version(unsigned compactVersion, CompactType);


### PR DESCRIPTION
Related: #28.

- bchd has various quirks that need workarounds and/or special cases.  With this PR, bchd synching and blockchain serving works.
- Refactored code to grab the bitcoind version info as early as possible, so that workarounds may be applied right away.
- All bitcoind quirk code is in 1 place now, BitcoinDMgr, where it belongs
- Fixed a minor bug (RPC error messages did not remember their original "method" -- this has been fixed).

