### PR TITLE
Refactor away some often-user boilerplate for bytes into ByteView

### DIFF
--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -207,6 +207,7 @@ HEADERS += \
     BitcoinD.h \
     BlockProc.h \
     BlockProcTypes.h \
+    ByteView.h \
     CityHash.h \
     Common.h \
     Compat.h \

--- a/src/BTC.h
+++ b/src/BTC.h
@@ -152,18 +152,18 @@ namespace BTC
     /// already randomized.
     template <typename BytesT>
     struct GenericTrivialHashHasher {
-        std::size_t operator()(const BytesT &b) const noexcept {
-            if (LIKELY(std::size_t(b.size()) >= sizeof(std::size_t))) {
+        static_assert(std::is_convertible_v<BytesT, ByteView>, "Assumption here is that BytesT has an implicit conversion to ByteView");
+
+        std::size_t operator()(const ByteView &bv) const noexcept {
+            if (LIKELY(bv.size() >= sizeof(std::size_t))) {
                 // common case, just return the first 8 bytes reinterpreted as size_t since this is already
                 // a random hash.
-                static_assert (std::is_scalar_v<std::remove_pointer_t<decltype (b.begin())>>,
-                               "GenericTrivialHasher must be used with a container type where .begin() returns a pointer to its data." );
                 std::size_t ret;
-                std::memcpy(reinterpret_cast<char *>(&ret), b.begin(), sizeof(ret));
+                std::memcpy(reinterpret_cast<char *>(&ret), bv.data(), sizeof(ret));
                 return ret;
             }
             // this should not normally be reached.
-            return Util::hashForStd(reinterpret_cast<const std::byte *>(b.begin()), std::size_t(b.size()));
+            return Util::hashForStd(bv);
         }
     };
 

--- a/src/ByteView.h
+++ b/src/ByteView.h
@@ -1,0 +1,90 @@
+//
+// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// Copyright (C) 2019-2020  Calin A. Culianu <calin.culianu@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program (see LICENSE.txt).  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+#pragma once
+
+#include <QByteArray>
+#include <QChar>
+#include <QString>
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+/// A pointer & size pair... intended to be used to encapsulate arguments to
+/// functions that accept generic byte blobs (such as a hasher, bloom filter,
+/// etc).
+///
+/// The purpose of this class is to offer some automatic type conversions from
+/// e.g. QByteArray, std::vector<podtype>, uint256, double, int... -> ByteView,
+/// which then can get passed to a hasher function.
+///
+/// Warning: This class is just like string_view, except it holds a
+/// `const std::byte *`.  As such, do *not* keep instances around unless the
+/// data being pointed-to is guaranteed to live for longer than the lifetime of
+/// the ByteView instance.
+class ByteView: public std::basic_string_view<std::byte>
+{
+    template <typename CharT, typename T, typename = std::enable_if_t<sizeof(CharT) == 1>>
+    static constexpr const CharT *ptr_cast(const T *t) {
+        // This trick gets past the "no reinterpret_cast in constexpr" rule.
+        // I wasn't sure if the below was an aliasing rule violation, but apparently it's not:
+        //   https://old.reddit.com/r/cpp/comments/hs6ut6/is_this_a_legal_use_of_pointer_casting_strict/
+        return static_cast<const CharT *>(static_cast<const void *>(t));
+    }
+public:
+    using Base = std::basic_string_view<std::byte>;
+    using Base::basic_string_view; // inherit constructors
+
+    /// Construct a ByteView from any POD data item.
+    template<typename T, std::enable_if_t<std::is_pod_v<T> && !std::is_pointer_v<T>, int> = 0>
+    constexpr ByteView(const T &t) noexcept
+        : ByteView(ptr_cast<std::byte>(&t), sizeof(t)) {}
+
+    /// Construct a ByteView from any container that offers a .data() method that is a pointer to POD data,
+    /// and a .size() method -- such as QByteArray, std::vector, QString, etc.
+    template<typename T,
+             std::enable_if_t<std::is_same_v<QString, T> /* special case for QString */ ||
+                              (std::is_pointer_v<decltype(std::declval<const T>().data())>
+                               && std::is_integral_v<decltype(std::declval<const T>().size())>
+                               && std::is_pod_v<std::remove_pointer_t<decltype(std::declval<const T>().data())>>
+                               && !std::is_pointer_v<std::remove_pointer_t<decltype(std::declval<const T>().data())>>), int> = 0>
+    constexpr ByteView(const T &t) noexcept
+        : ByteView(ptr_cast<std::byte>(t.data()), t.size() * sizeof(*t.data())) {
+        static_assert (!std::is_same_v<T, QString>
+                       || (std::is_same_v<const QChar *, decltype(t.data())> && sizeof(QChar) == sizeof(uint16_t)
+                           && std::has_unique_object_representations_v<QChar>),
+                       "Assumption for QString is that QChar is essentially a uint16_t");
+    }
+    constexpr const char * charData() const noexcept { return ptr_cast<char>(data()); }
+    constexpr const uint8_t * ucharData() const noexcept { return ptr_cast<uint8_t>(data()); }
+
+    constexpr std::string_view toStringView() const noexcept { return std::string_view{charData(), size()}; }
+
+    QByteArray toByteArray(bool deepCopy = true) const {
+        return deepCopy ? QByteArray{charData(), int(size())}
+                        : QByteArray::fromRawData(charData(), int(size()));
+    }
+};
+
+/// String literal -> ByteView e.g.: "foo"_bv or "\x01\xff\x07\xab"_bv
+inline constexpr ByteView operator "" _bv(const char *str, std::size_t len) noexcept {
+    return std::string_view{str, len}; // goes through template c'tor above..
+}

--- a/src/ByteView.h
+++ b/src/ByteView.h
@@ -43,40 +43,44 @@
 class ByteView: public std::basic_string_view<std::byte>
 {
     template <typename CharT, typename T, typename = std::enable_if_t<sizeof(CharT) == 1>>
-    static constexpr const CharT *ptr_cast(const T *t) {
-        // This trick gets past the "no reinterpret_cast in constexpr" rule.
-        // I wasn't sure if the below was an aliasing rule violation, but apparently it's not:
-        //   https://old.reddit.com/r/cpp/comments/hs6ut6/is_this_a_legal_use_of_pointer_casting_strict/
-        return static_cast<const CharT *>(static_cast<const void *>(t));
+    static const CharT *ptr_cast(const T *t) noexcept {
+        // This single line of code here prevents all the methods of this class from being constexpr :/
+        return reinterpret_cast<const CharT *>(t);
     }
+    // type trait to exclude C arrays but accept std::array
+    template<typename T> struct is_std_array : std::false_type {};
+    template<typename T, std::size_t N> struct is_std_array<std::array<T,N>> : std::true_type{};
+    template<typename T> static constexpr bool is_std_array_v = is_std_array<T>::value;
+
 public:
     using Base = std::basic_string_view<std::byte>;
     using Base::basic_string_view; // inherit constructors
 
-    /// Construct a ByteView from any POD data item.
-    template<typename T, std::enable_if_t<std::is_pod_v<T> && !std::is_pointer_v<T>, int> = 0>
-    constexpr ByteView(const T &t) noexcept
+    /// Construct a ByteView from any POD data item or C array (but not a std::array)
+    template<typename T, std::enable_if_t<std::is_pod_v<T> && !std::is_pointer_v<T> && !is_std_array_v<T>
+                                          && (!std::is_array_v<T> || !std::is_pointer_v<std::remove_all_extents_t<T>>), int> = 0>
+    ByteView(const T &t) noexcept
         : ByteView(ptr_cast<std::byte>(&t), sizeof(t)) {}
 
     /// Construct a ByteView from any container that offers a .data() method that is a pointer to POD data,
-    /// and a .size() method -- such as QByteArray, std::vector, QString, etc.
+    /// and a .size() method -- such as QByteArray, std::vector, QString, std::array, etc.
     template<typename T,
              std::enable_if_t<std::is_same_v<QString, T> /* special case for QString */ ||
                               (std::is_pointer_v<decltype(std::declval<const T>().data())>
                                && std::is_integral_v<decltype(std::declval<const T>().size())>
                                && std::is_pod_v<std::remove_pointer_t<decltype(std::declval<const T>().data())>>
                                && !std::is_pointer_v<std::remove_pointer_t<decltype(std::declval<const T>().data())>>), int> = 0>
-    constexpr ByteView(const T &t) noexcept
+    ByteView(const T &t) noexcept
         : ByteView(ptr_cast<std::byte>(t.data()), t.size() * sizeof(*t.data())) {
         static_assert (!std::is_same_v<T, QString>
                        || (std::is_same_v<const QChar *, decltype(t.data())> && sizeof(QChar) == sizeof(uint16_t)
                            && std::has_unique_object_representations_v<QChar>),
                        "Assumption for QString is that QChar is essentially a uint16_t");
     }
-    constexpr const char * charData() const noexcept { return ptr_cast<char>(data()); }
-    constexpr const uint8_t * ucharData() const noexcept { return ptr_cast<uint8_t>(data()); }
+    const char * charData() const noexcept { return ptr_cast<char>(data()); }
+    const uint8_t * ucharData() const noexcept { return ptr_cast<uint8_t>(data()); }
 
-    constexpr std::string_view toStringView() const noexcept { return std::string_view{charData(), size()}; }
+    std::string_view toStringView() const noexcept { return std::string_view{charData(), size()}; }
 
     QByteArray toByteArray(bool deepCopy = true) const {
         return deepCopy ? QByteArray{charData(), int(size())}
@@ -85,6 +89,6 @@ public:
 };
 
 /// String literal -> ByteView e.g.: "foo"_bv or "\x01\xff\x07\xab"_bv
-inline constexpr ByteView operator "" _bv(const char *str, std::size_t len) noexcept {
+inline ByteView operator "" _bv(const char *str, std::size_t len) noexcept {
     return std::string_view{str, len}; // goes through template c'tor above..
 }

--- a/src/ByteView.h
+++ b/src/ByteView.h
@@ -22,6 +22,7 @@
 #include <QChar>
 #include <QString>
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <string_view>

--- a/src/RPCMsgId.h
+++ b/src/RPCMsgId.h
@@ -103,14 +103,7 @@ private:
 template<> struct std::hash<RPCMsgId> {
     std::size_t operator()(const RPCMsgId &r) const {
         switch(r.typ) {
-        case RPCMsgId::String: {
-            static_assert (std::is_same_v<decltype(r.sdata.constBegin()), const QChar *>,
-                           "Assumption here is that QString::constBegin() returns a pointer");
-            // get pointers to underlying data, and hash that
-            const std::byte * const begin = reinterpret_cast<const std::byte *>(r.sdata.constBegin()),
-                            * const end   = reinterpret_cast<const std::byte *>(r.sdata.constEnd());
-            return Util::hashForStd(begin, std::size_t(end - begin));
-        }
+        case RPCMsgId::String: return Util::hashForStd(r.sdata);
         case RPCMsgId::Integer: return Util::hashForStd(r.idata);
         case RPCMsgId::Null: return 0;
         }
@@ -121,7 +114,7 @@ inline uint qHash(const RPCMsgId &r, uint seed = 0)  {
     switch(r.typ) {
     case RPCMsgId::String: return qHash(r.sdata, seed);
     case RPCMsgId::Integer: return qHash(r.idata, seed);
-    case RPCMsgId::Null: return 0;
+    case RPCMsgId::Null: return seed;
     }
 }
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -267,13 +267,13 @@ namespace Util {
         const HashSeed hashSeed;
     } // namespace (anonymous)
 
-    uint32_t hashData32(const std::byte *data, size_t len)
+    uint32_t hashData32(const ByteView &bv)
     {
-        return bitcoin::MurmurHash3(hashSeed.get<uint32_t>(), reinterpret_cast<const uint8_t *>(data), len);
+        return bitcoin::MurmurHash3(hashSeed.get<uint32_t>(), bv.ucharData(), bv.size());
     }
-    uint64_t hashData64(const std::byte *data, size_t len)
+    uint64_t hashData64(const ByteView &bv)
     {
-        return uint64_t(CityHash::CityHash64WithSeed(reinterpret_cast<const char *>(data), len, hashSeed.get<CityHash::uint64>()));
+        return uint64_t(CityHash::CityHash64WithSeed(bv.charData(), bv.size(), hashSeed.get<CityHash::uint64>()));
     }
 
 } // end namespace Util

--- a/src/Util.h
+++ b/src/Util.h
@@ -18,6 +18,7 @@
 //
 #pragma once
 
+#include "ByteView.h"
 #include "Common.h"
 #include <QtCore>
 
@@ -696,22 +697,20 @@ namespace Util {
     }
 
     /// uses MurmurHash3 with the unique seed initialized at app start
-    uint32_t hashData32(const std::byte *data, size_t dataLenBytes);
+    uint32_t hashData32(const ByteView &);
 
     /// uses CityHash64 with the unique seed initialized at app start
-    uint64_t hashData64(const std::byte *data, size_t dataLenBytes);
+    uint64_t hashData64(const ByteView &);
 
-    inline std::size_t hashForStd(const std::byte *data, std::size_t dataLenBytes) {
+    inline std::size_t hashForStd(const ByteView &bv) {
         constexpr auto size_t_size = sizeof(std::size_t);
         static_assert(size_t_size == sizeof(uint32_t) || size_t_size == sizeof(uint64_t));
         if constexpr (size_t_size == sizeof(uint64_t)) {
-            return std::size_t(hashData64(data, dataLenBytes));
+            return std::size_t(hashData64(bv));
         } else {
-            return std::size_t(hashData32(data, dataLenBytes));
+            return std::size_t(hashData32(bv));
         }
     }
-    template <typename T>
-    inline std::size_t hashForStd(const T &t) { return hashForStd(reinterpret_cast<const std::byte *>(&t), sizeof(t)); }
 
 } // end namespace Util
 

--- a/src/bitcoin/uint256.cpp
+++ b/src/bitcoin/uint256.cpp
@@ -20,17 +20,17 @@ namespace bitcoin {
 
 template <unsigned int BITS>
 base_blob<BITS>::base_blob(const std::vector<uint8_t> &vch) noexcept {
-    assert(vch.size() == sizeof(data));
-    memcpy(data, &vch[0], sizeof(data));
+    assert(vch.size() == sizeof(m_data));
+    memcpy(m_data, &vch[0], sizeof(m_data));
 }
 
 template <unsigned int BITS> std::string base_blob<BITS>::GetHex() const {
-    return HexStr(std::reverse_iterator<const uint8_t *>(data + sizeof(data)),
-                  std::reverse_iterator<const uint8_t *>(data));
+    return HexStr(std::reverse_iterator<const uint8_t *>(m_data + sizeof(m_data)),
+                  std::reverse_iterator<const uint8_t *>(m_data));
 }
 
 template <unsigned int BITS> void base_blob<BITS>::SetHex(const char *psz) {
-    memset(data, 0, sizeof(data));
+    memset(m_data, 0, sizeof(m_data));
 
     // skip leading spaces
     while (IsSpace(*psz)) {
@@ -49,7 +49,7 @@ template <unsigned int BITS> void base_blob<BITS>::SetHex(const char *psz) {
     }
 
     psz--;
-    uint8_t *p1 = (uint8_t *)data;
+    uint8_t *p1 = (uint8_t *)m_data;
     uint8_t *pend = p1 + WIDTH;
     while (psz >= pbegin && p1 < pend) {
         *p1 = bitcoin::HexDigit(*psz--);

--- a/src/bitcoin/uint256.h
+++ b/src/bitcoin/uint256.h
@@ -26,30 +26,29 @@ namespace bitcoin {
 
 /** Template base class for fixed-sized opaque blobs. */
 template <unsigned int BITS> class base_blob {
-protected:
     static constexpr int WIDTH = BITS / 8;
-    uint8_t data[WIDTH];
+    uint8_t m_data[WIDTH];
 
 public:
-    constexpr base_blob() noexcept : data{0} { }
+    constexpr base_blob() noexcept : m_data{0} { }
 
     explicit base_blob(const std::vector<uint8_t> &vch) noexcept;
 
     constexpr bool IsNull() const noexcept {
         for (int i = 0; i < WIDTH; i++) {
-            if (data[i] != 0) {
+            if (m_data[i] != 0) {
                 return false;
             }
         }
         return true;
     }
 
-    void SetNull() noexcept { std::memset(data, 0, sizeof(data)); }
+    void SetNull() noexcept { std::memset(m_data, 0, sizeof(m_data)); }
 
     constexpr int Compare(const base_blob &other) const noexcept {
-        for (size_t i = 0; i < sizeof(data); i++) {
-            uint8_t a = data[sizeof(data) - 1 - i];
-            uint8_t b = other.data[sizeof(data) - 1 - i];
+        for (size_t i = 0; i < sizeof(m_data); i++) {
+            uint8_t a = m_data[sizeof(m_data) - 1 - i];
+            uint8_t b = other.m_data[sizeof(m_data) - 1 - i];
             if (a != b) {
                 if (a > b)
                     return 1;
@@ -85,20 +84,23 @@ public:
     void SetHex(const std::string &str);
     std::string ToString() const { return GetHex(); }
 
-    constexpr uint8_t *begin() noexcept { return &data[0]; }
+    constexpr uint8_t *begin() noexcept { return &m_data[0]; }
 
-    constexpr uint8_t *end() noexcept { return &data[WIDTH]; }
+    constexpr uint8_t *end() noexcept { return &m_data[WIDTH]; }
 
-    constexpr const uint8_t *begin() const noexcept { return &data[0]; }
+    constexpr const uint8_t *begin() const noexcept { return &m_data[0]; }
 
-    constexpr const uint8_t *end() const noexcept { return &data[WIDTH]; }
+    constexpr const uint8_t *end() const noexcept { return &m_data[WIDTH]; }
 
-    constexpr unsigned int size() const noexcept { return sizeof(data); }
+    constexpr uint8_t *data() noexcept { return begin(); }
+    constexpr const uint8_t *data() const noexcept { return begin(); }
+
+    constexpr unsigned int size() const noexcept { return sizeof(m_data); }
 
     static constexpr int width() noexcept { return WIDTH; } // added by Calin
 
     constexpr uint64_t GetUint64(int pos) const noexcept {
-        const uint8_t *ptr = data + pos * 8;
+        const uint8_t *ptr = m_data + pos * 8;
         return uint64_t(ptr[0]) | (uint64_t(ptr[1]) << 8) |
                (uint64_t(ptr[2]) << 16) | (uint64_t(ptr[3]) << 24) |
                (uint64_t(ptr[4]) << 32) | (uint64_t(ptr[5]) << 40) |
@@ -106,11 +108,11 @@ public:
     }
 
     template <typename Stream> void Serialize(Stream &s) const {
-        s.write((char *)data, sizeof(data));
+        s.write((char *)m_data, sizeof(m_data));
     }
 
     template <typename Stream> void Unserialize(Stream &s) {
-        s.read((char *)data, sizeof(data));
+        s.read((char *)m_data, sizeof(m_data));
     }
 };
 
@@ -147,7 +149,7 @@ public:
      * appropriate when the value can easily be influenced from outside as e.g.
      * a network adversary could provide values to trigger worst-case behavior.
      */
-    uint64_t GetCheapHash() const { return ReadLE64(data); }
+    uint64_t GetCheapHash() const { return ReadLE64(data()); }
 };
 
 /**


### PR DESCRIPTION
When implementing the `RollingBloomFilter` (and the TrivialHashHasher)
there was ugly boilerplate: multiple overloads doing repetitive 
`reinterpret_casts`, in order to support various POD types as well as 
`QByteArray`, `std::vector`, etc.  All of this has been refactored into a 
utility class, `ByteView`, which has  templated auto-conversions from 
often used containers, e.g.: `base_blob`,  `QString`, `QByteArray`, 
`std::vector`, etc.

This class is is a zero-cost abstraction that compiles away into nothing.  
It is lightweight and inherits from `std::basic_string_view` but its underlying 
type is `const std::byte *` (rather than `const char *`).

It is intended to encapsulate a pointer, size pair into binary data
blobs, and its intended use is as an argument on the stack to hasher
functions, bloom filters, and other such functions that take byte pointers
into arbitrary data.

In addition, our `base_blob` type that we copied over from bitcoin sources
has been refactored to be more STL-like in its api.
