### PR TITLE
WebSocket: Correctly handle multiple values in the Connection header

### DIFF
--- a/src/WebSocket.h
+++ b/src/WebSocket.h
@@ -276,6 +276,7 @@ namespace WebSocket
 
                 int nread = 0;
                 QHash<QString, QString> headers;
+                bool checkHeaders(QString *what = nullptr) const;
 
                 /// called from derived classes' start(), returns false if should abort start(), emits failure(reason)
                 /// on false return.  On true return, sets up some private signal/slot connections for emitting failure


### PR DESCRIPTION
Some user agents send a comma separated list of values in the connection header so this needs to be handled correctly. It is enough if one of the values is "upgrade" now.

This also moves the header checking code into the `ClientServerBase` to consolidate the checks for client and server.

closes #36