### PR TITLE
ServerSSL: Do not request client certificates from clients

### DIFF
--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -1915,6 +1915,7 @@ void ServerSSL::setupSslConfiguration()
         // not a self-signed cert -- we need the full chain
         sslConfiguration.setLocalCertificateChain(chain);
     sslConfiguration.setProtocol(QSsl::SslProtocol::AnyProtocol);
+    sslConfiguration.setPeerVerifyMode(QSslSocket::VerifyNone);
 }
 void ServerSSL::incomingConnection(qintptr socketDescriptor)
 {


### PR DESCRIPTION
While the default is `QSslSocket::QueryPeer` this will prompt many browsers to unlock their certificate stores and fail if that does not work. Instead we should never ask for a client certificate.
