### PR TITLE
WebSocket: flush socket before exception to make errors reliable

### DIFF
--- a/src/WebSocket.cpp
+++ b/src/WebSocket.cpp
@@ -776,6 +776,7 @@ namespace WebSocket
                             "%4"
                         ).arg(code).arg(reason).arg(content.size()).arg(QString::fromLatin1(content)).toLatin1();
                         sock->write(resp);
+                        sock->flush();
                         throw Exception(what);
                     };
                     while (sock->canReadLine()) {


### PR DESCRIPTION
Before this it was random whether a client would receive a 0 byte response or the error string.