### PR TITLE
Docker: Preload jemalloc to reduce heap fragmentation

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -y && \
     add-apt-repository ppa:beineri/opt-qt-5.13.2-bionic && \
     apt-get update -y && \
     apt-get install -y qt513base openssl && \
-    apt-get install -y git build-essential zlib1g-dev libbz2-dev && \
+    apt-get install -y git build-essential zlib1g-dev libbz2-dev libjemalloc1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -27,6 +27,8 @@ ENV DATA_DIR /data
 
 ENV SSL_CERTFILE ${DATA_DIR}/fulcrum.crt
 ENV SSL_KEYFILE ${DATA_DIR}/fulcrum.key
+
+ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so.1
 
 EXPOSE 50001 50002
 


### PR DESCRIPTION
Jemalloc is better suited for the memory usage pattern of Fulcrum, which is allocating/freeing lots of random sized buffers from multiple threads, resulting in lots of fragmentation.

Jemalloc is a general purpose `malloc(3)` implementation that emphasizes fragmentation avoidance and scalable concurrency support.

`gdb` was used to check the `malloc` symbol comes from `libjemalloc.so.1`