### PR TITLE
Build: Add test for rocksdb availability and minimum version

### DIFF
--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -17,9 +17,8 @@
 # <https://www.gnu.org/licenses/>.
 #
 
-!defined(features, var) {
-    features = staticlibs
-}
+# Make qtCompileTest available
+load(configure)
 
 QT -= gui
 QT += network
@@ -92,7 +91,9 @@ linux-g++ {
     CONFIG += warn_off
 }
 
-contains(features, staticlibs) {
+# Test if rocksdb is installed and meets the minimum version requirement
+qtCompileTest(rocksdb)
+!contains(CONFIG, config_rocksdb) {
     # RocksDB Static Lib
     # ------------------
     #
@@ -155,7 +156,7 @@ linux {
 }
 win32 {
     LIBS += -lrocksdb -lshlwapi -lrpcrt4
-    !contains(features, staticlibs) {
+    contains(CONFIG, config_rocksdb) {
         LIBS += -lzstd -lbz2 -llz4 -lsnappy -lz
     }
 }

--- a/config.tests/rocksdb/main.cpp
+++ b/config.tests/rocksdb/main.cpp
@@ -1,0 +1,25 @@
+#include <array>
+#include <cstddef>
+#include <rocksdb/version.h>
+
+constexpr int minimumVersion[] = {6, 6, 4};
+constexpr int version[] = {ROCKSDB_MAJOR, ROCKSDB_MINOR, ROCKSDB_PATCH};
+
+constexpr bool compareVersion(const int *version1, const int *version2, const size_t length)
+{
+    for (size_t i = 0; i < length; i++) {
+        if (version1[i] > version2[i]) {
+            return true;
+        } else if (version1[i] < version2[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static_assert(compareVersion(version, minimumVersion, std::size(version)));
+
+int main()
+{
+    return 0;
+}

--- a/config.tests/rocksdb/test.pro
+++ b/config.tests/rocksdb/test.pro
@@ -1,0 +1,2 @@
+SOURCES = main.cpp
+LIBS += -lrocksdb


### PR DESCRIPTION
This will use the system `rocksdb` if it is available and meets the minimum version requirement, otherwise it will use the prebuilt static library.