### PR TITLE
Build: Add test for jemalloc and link it if found

### DIFF
--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -148,6 +148,12 @@ qtCompileTest(rocksdb)
     # /RocksDB Static Lib
 }
 
+# Test if jemalloc is installed
+qtCompileTest(jemalloc)
+contains(CONFIG, config_jemalloc) {
+    LIBS += -ljemalloc
+}
+
 macx {
     LIBS += -lrocksdb -lz -lbz2
 }

--- a/config.tests/jemalloc/main.cpp
+++ b/config.tests/jemalloc/main.cpp
@@ -1,0 +1,13 @@
+#include <cstdlib>
+#include <jemalloc/jemalloc.h>
+
+int main()
+{
+    if (malloc(1) == nullptr)
+        return 1;
+
+    if (mallocx(1, MALLOCX_ZERO) == nullptr)
+        return 1;
+
+    return 0;
+}

--- a/config.tests/jemalloc/test.pro
+++ b/config.tests/jemalloc/test.pro
@@ -1,0 +1,3 @@
+SOURCES = main.cpp
+LIBS += -ljemalloc
+DEFINES += JEMALLOC_MANGLE


### PR DESCRIPTION
Jemalloc is better suited for the memory usage pattern of Fulcrum, which is allocating/freeing lots of random sized buffers from multiple threads, resulting in lots of fragmentation.

Jemalloc is a general purpose `malloc(3)` implementation that emphasizes fragmentation avoidance and scalable concurrency support.
