### PR TITLE
RocksDB: Check if C++ interface is exported by the system library

### DIFF
--- a/config.tests/rocksdb/main.cpp
+++ b/config.tests/rocksdb/main.cpp
@@ -1,6 +1,7 @@
 #include <array>
 #include <cstddef>
 #include <rocksdb/version.h>
+#include <rocksdb/db.h>
 
 constexpr int minimumVersion[] = {6, 6, 4};
 constexpr int version[] = {ROCKSDB_MAJOR, ROCKSDB_MINOR, ROCKSDB_PATCH};
@@ -21,5 +22,8 @@ static_assert(compareVersion(version, minimumVersion, std::size(version)));
 
 int main()
 {
+    rocksdb::DB* db;
+    rocksdb::Options options;
+    rocksdb::DB::Open(options, "", &db);
     return 0;
 }


### PR DESCRIPTION
Shared Windows builds of RocksDB produce a .dll file that only dllexports the C interface of RocksDB, which will cause the config tests to use the system library but link will fail because the C++ symbols are undefined.

This patch makes the config test link to the C++ interface to check if the system library exports the C++ symbols.