### PR TITLE
Fix mempool synch performance when tx's are dropped

### DIFF
--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -79,7 +79,7 @@ DEFINES += USE_QT_IN_BITCOIN
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 # If defined, tests and benchmarks will be compiled-in to the app (accessed via --test and --bench CLI args).
-#DEFINES += ENABLE_TESTS
+DEFINES += ENABLE_TESTS
 
 win32-msvc {
     error("MSVC is not supported for this project. Please compile with MinGW G++ 7.3.0 or above.")

--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -79,7 +79,7 @@ DEFINES += USE_QT_IN_BITCOIN
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 # If defined, tests and benchmarks will be compiled-in to the app (accessed via --test and --bench CLI args).
-DEFINES += ENABLE_TESTS
+#DEFINES += ENABLE_TESTS
 
 win32-msvc {
     error("MSVC is not supported for this project. Please compile with MinGW G++ 7.3.0 or above.")

--- a/contrib/rpm/fulcrum.spec
+++ b/contrib/rpm/fulcrum.spec
@@ -1,5 +1,5 @@
 Name:    {{{ git_name name="fulcrum" }}}
-Version: 1.3.1
+Version: 1.3.2
 Release: {{{ git_version }}}%{?dist}
 Summary: A fast & nimble SPV server for Bitcoin Cash
 

--- a/doc/unix-man-page.md
+++ b/doc/unix-man-page.md
@@ -1,6 +1,6 @@
-% FULCRUM(1) Version 1.3.1 | Fulcrum Manual
+% FULCRUM(1) Version 1.3.2 | Fulcrum Manual
 % Fulcrum is written by Calin Culianu (cculianu)
-% November 11, 2020
+% December 04, 2020
 
 # NAME
 

--- a/src/Common.h
+++ b/src/Common.h
@@ -39,7 +39,7 @@ struct InternalError : Exception { using Exception::Exception; ~InternalError() 
 struct BadArgs : Exception { using Exception::Exception; ~BadArgs() override; };
 
 #define APPNAME "Fulcrum"
-#define VERSION "1.3.1"
+#define VERSION "1.3.2"
 #ifdef QT_DEBUG
 #  define VERSION_EXTRA "(Debug)"
 inline constexpr bool isReleaseBuild() { return false; }

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -536,7 +536,7 @@ struct SynchMempoolTask : public CtlTask
     Mempool::TxMap txsNeedingDownload, txsWaitingForResponse;
     Mempool::NewTxsMap txsDownloaded;
     unsigned expectedNumTxsDownloaded = 0;
-    static constexpr int kRedoCtMax = 5; // if we fail this many times, error out.
+    static constexpr int kRedoCtMax = 5; // if we have to retry this many times, error out.
     int redoCt = 0;
     const bool TRACE = Trace::isEnabled(); // set this to true to print more debug
     const bool isBTC; ///< initted in c'tor. If true, deserialize tx's using the optional segwit extensons to the tx format.
@@ -652,7 +652,7 @@ void SynchMempoolTask::processResults()
     }
     const auto [oldSize, newSize, oldNumAddresses, newNumAddresses] = [this] {
         const auto getFromDB = [this](const TXO &prevTXO) -> std::optional<TXOInfo> {
-            // this is a callback called from whithin addNewTxs() below when encountering
+            // this is a callback called from within addNewTxs() below when encountering
             // a confirmed spend.
             return storage->utxoGetFromDB(prevTXO, false); // this may throw on low-level db error
         };

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -728,8 +728,9 @@ void SynchMempoolTask::doDLNextTx()
         AGAIN();
     },
     [this, hashHex, tx](const RPC::Message &resp) {
-        // Continue on error -- if we fail to retrieve the transaction then it's possible that there was some RBF action
-        // if on BTC, or the tx happened to drop out of mempool for some other reason. We continue anyway.
+        // Retry on error -- if we fail to retrieve the transaction then it's possible that there was some RBF action
+        // if on BTC, or the tx happened to drop out of mempool for some other reason. We must retry to ensure a
+        // consistent view of bitcoind's mempool.
         const auto *const pre = isBTC ? "Tx dropped out of mempool (possibly due to RBF)" : "Tx dropped out of mempool";
         Warning() << pre << ": " << QString(hashHex) << " (error response: " << resp.errorMessage()
                   << "), retrying getrawmempool ...";

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -215,9 +215,9 @@ protected:
     void on_failure(const RPC::Message::Id &, const QString &msg);
 
     using ResultsF = BitcoinDMgr::ResultsF;
+    using ErrorF = BitcoinDMgr::ErrorF;
     quint64 submitRequest(const QString &method, const QVariantList &params, const ResultsF &resultsFunc,
-                          // this string should point to a persistent C string (such as a literal) or nullptr
-                          const char *recommendRetryOnErrorWithMsg = nullptr);
+                          const ErrorF &errorFunc = {});
 
     Controller * const ctl; ///< initted in c'tor. Is always valid since all tasks' lifecycles are managed by the Controller.
     const int reqTimeout; ///< initted in c'tor, cached from ctl->options->bdTimeout

--- a/src/Mempool.cpp
+++ b/src/Mempool.cpp
@@ -349,7 +349,7 @@ auto Mempool::dropTxs(ScriptHashesAffectedSet & scriptHashesAffectedOut, const T
         if (txs.load_factor() <= *rehashMaxLoadFactor)
             txs.rehash(0); // shrink to fit
         if (hashXTxs.load_factor() <= *rehashMaxLoadFactor)
-            hashXTxs.rehash(0);  // shrint to fit
+            hashXTxs.rehash(0);  // shrink to fit
     }
     return ret;
 }

--- a/src/Mempool.cpp
+++ b/src/Mempool.cpp
@@ -146,7 +146,8 @@ auto Mempool::addNewTxs(ScriptHashesAffectedSet & scriptHashesAffected,
                 // prev is a confirmed tx
                 const auto optTXOInfo = getTXOInfo(prevTXO); // this may also throw on low-level db error
                 if (UNLIKELY(!optTXOInfo.has_value())) {
-                    // Uh oh. If it wasn't in the mempool or in the db.. something is very wrong with our code.
+                    // Uh oh. If it wasn't in the mempool or in the db.. something is very wrong with our code...
+                    // (or there maybe was a race condition and a new block came in while we were doing this).
                     // We will throw if missing, and the synch process aborts and hopefully we recover with a reorg
                     // or a new block or somesuch.
                     throw InternalError(QString("FAILED TO FIND PREVIOUS TX %1 IN EITHER MEMPOOL OR DB for TxHash: %2 (input %3)")

--- a/src/Mempool.cpp
+++ b/src/Mempool.cpp
@@ -19,6 +19,7 @@
 #include "Mempool.h"
 
 #include <algorithm>
+#include <cassert>
 #include <functional>
 #include <map>
 
@@ -52,3 +53,393 @@ auto Mempool::calcCompactFeeHistogram(double binSize) const -> FeeHistogramVec
     ret.shrink_to_fit(); // save memory
     return ret;
 }
+
+auto Mempool::addNewTxs(ScriptHashesAffectedSet & scriptHashesAffected,
+                        const NewTxsMap & txsDownloaded,
+                        const GetTXOInfoFromDBFunc & getTXOInfo,
+                        bool TRACE) -> Stats
+{
+    Stats ret;
+    auto & [oldSize, newSize, oldNumAddresses, newNumAddresses] = ret;
+    oldSize = this->txs.size();
+    oldNumAddresses = this->hashXTxs.size();
+    // first, do new outputs for all tx's, and put the new tx's in the mempool struct
+    for (auto & [hash, pair] : txsDownloaded) {
+        auto & [tx, ctx] = pair;
+        assert(hash == tx->hash);
+        this->txs[tx->hash] = tx; // save tx right now to map, since we need to find it later for possible spends, etc if subsequent tx's refer to this tx.
+        IONum n = 0;
+        const auto numTxo = ctx->vout.size();
+        if (LIKELY(tx->txos.size() != numTxo)) {
+            // we do it this way (reserve then resize) to avoid the automatic 2^N prealloc of normal vector .resize()
+            tx->txos.reserve(numTxo);
+            tx->txos.resize(numTxo);
+        }
+        for (const auto & out : ctx->vout) {
+            const auto & script = out.scriptPubKey;
+            if (!BTC::IsOpReturn(script)) {
+                // UTXO only if it's not OP_RETURN -- can't do 'continue' here as that would throw off the 'n' counter
+                HashX sh = BTC::HashXFromCScript(out.scriptPubKey);
+                // the below is a hack to save memory by re-using the same shallow copy of 'sh' each time
+                auto hxit = this->hashXTxs.find(sh);
+                if (hxit != this->hashXTxs.end()) {
+                    // found existing, re-use sh as a shallow copy
+                    sh = hxit->first;
+                } else {
+                    // new entry, insert, update hxit
+                    auto pair = this->hashXTxs.emplace(std::piecewise_construct,
+                                                       std::forward_as_tuple(sh), std::forward_as_tuple());
+                    hxit = pair.first;
+                }
+                // end memory saving hack
+                TXOInfo &txoInfo = tx->txos[n];
+                txoInfo = TXOInfo{out.nValue, sh, {}, {}};
+                tx->hashXs[sh].utxo.insert(n);
+                hxit->second.push_back(tx); // save tx to hashx -> tx vector (amortized constant time insert at end -- we will sort and uniqueify this at end of this function)
+                scriptHashesAffected.insert(sh);
+                assert(txoInfo.isValid());
+            }
+            tx->fee -= out.nValue; // update fee (fee = ins - outs, so we "add" the outs as a negative)
+            ++n;
+        }
+        assert(n == numTxo);
+        // . <-- at this point the .txos vec is built, with everything isValid() except for the OP_RETURN outs, which are all !isValid()
+    }
+    // next, do new inputs for all tx's, debiting/crediting either a mempool tx or querying db for the relevant utxo
+    for (auto & [hash, pair] : txsDownloaded) {
+        auto & [tx, ctx] = pair;
+        assert(hash == tx->hash);
+        IONum inNum = 0;
+        for (const auto & in : ctx->vin) {
+            const IONum prevN = IONum(in.prevout.GetN());
+            const TxHash prevTxId = BTC::Hash2ByteArrayRev(in.prevout.GetTxId());
+            const TXO prevTXO{prevTxId, prevN};
+            TXOInfo prevInfo;
+            QByteArray sh; // shallow copy of prevInfo.hashX
+            if (auto it = this->txs.find(prevTxId); it != this->txs.end()) {
+                // prev is a mempool tx
+                tx->hasUnconfirmedParentTx = true; ///< mark the current tx we are processing as having an unconfirmed parent (this is used for sorting later and by the get_mempool & listUnspent code)
+                auto prevTxRef = it->second;
+                assert(bool(prevTxRef));
+                if (prevN >= prevTxRef->txos.size()
+                        || !(prevInfo = prevTxRef->txos[prevN]).isValid())
+                    // defensive programming paranoia
+                    throw InternalError(QString("FAILED TO FIND A VALID PREVIOUS TXOUTN %1:%2 IN MEMPOOL for TxHash: %3 (input %4)")
+                                        .arg(QString(prevTxId.toHex())).arg(prevN).arg(QString(hash.toHex())).arg(inNum));
+                sh = prevInfo.hashX;
+                tx->hashXs[sh].unconfirmedSpends[prevTXO] = prevInfo;
+                prevTxRef->hashXs[sh].utxo.erase(prevN); // remove this spend from utxo set for prevTx in mempool
+                if (TRACE) Debug() << hash.toHex() << " unconfirmed spend: " << prevTXO.toString() << " " << prevInfo.amount.ToString().c_str();
+            } else {
+                // prev is a confirmed tx
+                const auto optTXOInfo = getTXOInfo(prevTXO); // this may also throw on low-level db error
+                if (UNLIKELY(!optTXOInfo.has_value())) {
+                    // Uh oh. If it wasn't in the mempool or in the db.. something is very wrong with our code.
+                    // We will throw if missing, and the synch process aborts and hopefully we recover with a reorg
+                    // or a new block or somesuch.
+                    throw InternalError(QString("FAILED TO FIND PREVIOUS TX %1 IN EITHER MEMPOOL OR DB for TxHash: %2 (input %3)")
+                                        .arg(prevTXO.toString()).arg(QString(hash.toHex())).arg(inNum));
+                }
+                prevInfo = *optTXOInfo;
+                sh = prevInfo.hashX;
+                // hack to save memory by re-using existing sh QByteArray and/or forcing a shallow-copy
+                auto hxit = tx->hashXs.find(sh);
+                if (hxit != tx->hashXs.end()) {
+                    // existing found, re-use same unerlying QByteArray memory for sh
+                    sh = prevInfo.hashX = hxit->first;
+                } else {
+                    // new entry, insert, update hxit
+                    auto pair = tx->hashXs.insert({sh, decltype(hxit->second)()});
+                    hxit = pair.first;
+                }
+                // end memory saving hack
+                hxit->second.confirmedSpends[prevTXO] = prevInfo;
+                if (TRACE) Debug() << hash.toHex() << " confirmed spend: " << prevTXO.toString() << " " << prevInfo.amount.ToString().c_str();
+            }
+            tx->fee += prevInfo.amount;
+            assert(sh == prevInfo.hashX);
+            this->hashXTxs[sh].push_back(tx); // mark this hashX as having been "touched" because of this input (note we push dupes here out of order but sort and uniqueify at the end)
+            scriptHashesAffected.insert(sh);
+            ++inNum;
+        }
+
+        // Now, compactify some data structures to take up less memory by rehashing thier unordered_maps/unordered_sets..
+        // we do this once for each new tx we see.. and it can end up saving tons of space. Note the below structures
+        // are either fixed in size or will only ever shrink as the mempool evolves so this is a good time to do this.
+        tx->hashXs.rehash(tx->hashXs.size());
+        for (auto & [sh, ioinfo] : tx->hashXs) {
+            ioinfo.confirmedSpends.rehash(ioinfo.confirmedSpends.size());  // this is fixed once built
+            ioinfo.unconfirmedSpends.rehash(ioinfo.unconfirmedSpends.size()); // this is fixed once built
+            ioinfo.utxo.rehash(ioinfo.utxo.size()); // this may shrink but we rehash it once now to the largest size it will ever have
+        }
+    }
+
+    // now, sort and uniqueify data structures made temporarily inconsistent above (have dupes, are out-of-order)
+    for (const auto & sh : scriptHashesAffected) {
+        if (auto it = this->hashXTxs.find(sh); LIKELY(it != this->hashXTxs.end()))
+            Util::sortAndUniqueify<Mempool::TxRefOrdering>(it->second);
+        //else {}
+        // Note: It's possible for the scriptHashesAffected set to refer to sh's no longer in the mempool because
+        // we sometimes retry this task when we detect mempool drops, with the scriptHasesAffected set containing
+        // the dropped address hashes.  This is why the if conditional above exists.
+    }
+
+    newSize = this->txs.size();
+    newNumAddresses = this->hashXTxs.size();
+    return ret;
+}
+
+auto Mempool::dropTxs(ScriptHashesAffectedSet & scriptHashesAffectedOut,
+                      const TxHashSet & txids,
+                      bool TRACE) -> Stats
+{
+    Stats ret;
+    ScriptHashesAffectedSet scriptHashesAffected;
+    auto & [oldSize, newSize, oldNumAddresses, newNumAddresses] = ret;
+    oldSize = this->txs.size();
+    oldNumAddresses = this->hashXTxs.size();
+
+    // first, undo unconfirmed spends -- find the parent txs and credit back the IOInfos for corresponding scripthashes
+    for (const auto & txid : txids) {
+        auto it = txs.find(txid);
+        if (UNLIKELY(it == txs.end())) {
+            Warning() << "dropTxs: tx " << Util::ToHexFast(txid) << " not found in mempool";
+            continue;
+        }
+        auto & tx = it->second;
+        // for each hashX this tx affects, look for unconfirmed spends
+        for (const auto & [hashX, ioinfo]: tx->hashXs) {
+            scriptHashesAffected.insert(hashX); // update affected set with all addresses for this tx
+            // for each unconfirmed spend, go to the previous tx in mempool and add back the utxo to ioinfo.utxo for the parent tx hashx entry
+            for (const auto & [txo, txoinfo] : ioinfo.unconfirmedSpends) {
+                scriptHashesAffected.insert(txoinfo.hashX); // updated affected set with address of txo we spent as well
+                auto prevIt = txs.find(txo.txHash);
+                if (LIKELY(prevIt != txs.end())) {
+                    auto & prevTx = prevIt->second;
+                    if (LIKELY(txo.outN < prevTx->txos.size())) {
+                        auto & prevTxoInfo = prevTx->txos[txo.outN];
+                        if (UNLIKELY(txoinfo != prevTxoInfo)) {
+                            Warning() << "dropTxs: Previous out " << txo.txHash.toHex() << ":" << txo.outN << " -- "
+                                      << "expected TXOInfo for this tx to match with spending tx " << txid.toHex()
+                                      << "'s TXOInfo! FIXME!";
+                        }
+                        if (UNLIKELY(prevTxoInfo.hashX != hashX)) {
+                            Warning() << "dropTxs: Previous out " << txo.txHash.toHex() << ":" << txo.outN << " -- "
+                                      << "expected TXOInfo for this tx to have hashX " << hashX.toHex()
+                                      << ", but it did not! FIXME!";
+                        }
+                        auto prevHashXsIt = prevTx->hashXs.find(hashX);
+                        if (LIKELY(prevHashXsIt != prevTx->hashXs.end())) {
+                            auto & previoinfo = prevHashXsIt->second;
+                            // this does the actual "crediting" back of the spend to the parent tx
+                            assert(txo.isValid());
+                            previoinfo.utxo.insert(txo.outN);
+                            if (TRACE)
+                                Debug() << "dropTxs: for txid " << Util::ToHexFast(txid) << " crediting "
+                                        << txo.txHash.toHex() << ":" << txo.outN << " amount "
+                                        << txoinfo.amount.ToString() << " back to hashX " << Util::ToHexFast(hashX);
+                        } else {
+                            Warning() << "dropTxs: Previous out " << txo.txHash.toHex() << ":" << txo.outN << " -- "
+                                      << "cannot find hashX " << hashX.toHex() << " in tx map! FIXME!";
+                        }
+                    } else {
+                        Warning() << "dropTxs: Previous out " << txo.txHash.toHex() << ":" << txo.outN << " is "
+                                  << " invalid (this output is spent by the dropped tx " << txid.toHex() << ")! FIXME!";
+                    }
+                } else {
+                    Warning() << "dropTxs: Previous tx " << txo.txHash.toHex() << " which has outputs spent by "
+                              << "(dropped) tx " << txid.toHex() << " is not found in mempool! This is unexpected! FIXME!";
+                }
+            }
+        }
+    }
+
+    // next, scan hashXs, removing entries for the txids in question
+    for (const auto & hashX : scriptHashesAffected) {
+        auto it = hashXTxs.find(hashX);
+        if (UNLIKELY(it == hashXTxs.end())) {
+            Warning() << "dtopTxs: Could not find hashX " << hashX.toHex() << " in hashXTxs map! FIXME!";
+            continue;
+        }
+        auto & txvec = it->second;
+        std::vector<TxRef> newvec;
+        newvec.reserve(txvec.size());
+        for (auto &txref : txvec) {
+            // filter out txids in the set
+            if (txids.count(txref->hash) == 0)
+                // not in txid set; copy it to newvec
+                newvec.push_back(txref);
+        }
+        if (!newvec.empty() && newvec.size() != txvec.size()) {
+            // swap the vectors with the one not containing the affected txids
+            if (TRACE) {
+                const auto oldsz = txvec.size(), newsz = newvec.size();
+                if (TRACE)
+                    Debug() << "dropTxs: Shrunk hashX " << Util::ToHexFast(hashX) << " txvec from size " << oldsz
+                            << " to size " << newsz;
+            }
+            txvec.swap(newvec);
+            txvec.shrink_to_fit();
+        } else if (newvec.empty()){
+            // if the new vector is empty meaning this hashX should disappear from the hashXTxs map!
+            hashXTxs.erase(it);
+            if (TRACE) Debug() << "dropTxs: Removed hashX " << Util::ToHexFast(hashX) << " which now has no txs in mempool";
+        }
+    }
+
+    // next, erase the txid's in question from the txs map
+    for (const auto & txid : txids) {
+        txs.erase(txid);
+    }
+
+    // finally, update scriptHashesAffectedOut
+    scriptHashesAffectedOut.merge(scriptHashesAffected);
+
+    // update returned stats
+    newSize = this->txs.size();
+    newNumAddresses = this->hashXTxs.size();
+    return ret;
+}
+
+#ifdef ENABLE_TESTS
+#include "App.h"
+#include "BTC.h"
+#include "Util.h"
+
+#include "bitcoin/amount.h"
+#include "bitcoin/streams.h"
+#include "bitcoin/transaction.h"
+#include "robin_hood/robin_hood.h"
+
+#include <cstdio>
+#include <set>
+
+namespace {
+    using MPData = Mempool::NewTxsMap;
+
+    MPData loadMempoolDat(const QString &fname) {
+        // Below code taken from BCHN validation.cpp
+        FILE *pfile = std::fopen(fname.toUtf8().constData(), "rb");
+        bitcoin::CAutoFile file(pfile, bitcoin::SER_DISK, bitcoin::PROTOCOL_VERSION | bitcoin::SERIALIZE_TRANSACTION_USE_WITNESS);
+        if (file.IsNull())
+            throw Exception(QString("Failed to open mempool file '%1'").arg(fname));
+
+        std::size_t dataTotal = 0;
+        const auto t0 = Util::getTimeMicros();
+
+        MPData ret;
+        try {
+            uint64_t version;
+            file >> version;
+            constexpr uint64_t BCHN_BTC_VERSION = 1, BU_VERSION = 1541030400;
+            if (!std::set{{BCHN_BTC_VERSION, BU_VERSION}}.count(version))
+                throw Exception(QString("Unknown mempool.dat version: %1").arg(qulonglong(version)));
+
+            uint64_t num;
+            file >> num;
+            while (num--) {
+                bitcoin::CTransactionRef ctx;
+                int64_t nTime;
+                int64_t nFeeDelta;
+                file >> ctx;
+                file >> nTime;
+                file >> nFeeDelta;
+
+                auto rtx = std::make_shared<Mempool::Tx>();
+                rtx->hash = BTC::Hash2ByteArrayRev(ctx->GetHashRef());
+                dataTotal += rtx->sizeBytes = ctx->GetTotalSize(true);
+                ret.emplace(std::piecewise_construct,
+                            std::forward_as_tuple(rtx->hash),
+                            std::forward_as_tuple(std::move(rtx), std::move(ctx)));
+            }
+        } catch (const std::exception &e) {
+            throw Exception(QString("Failed to deserialize mempool data: %1").arg(e.what()));
+        }
+        Log("Imported mempool: %d txs, %1.2f MB in %1.3f msec", int(ret.size()), dataTotal / 1e6, (Util::getTimeMicros()-t0)/1e3);
+        return ret;
+    }
+
+    void bench() {
+        const char * const mpdat = std::getenv("MPDAT");
+        if (!mpdat) {
+            Warning() << "Mempool benchmark requires the MPDAT environment variable, which should be a path to a "
+                         "mempool.dat taken from either BCHN, BU, or a BTC (Core) bitcoind..";
+            throw Exception("No MPDAT specified");
+        }
+
+        const auto mem0 = Util::getProcessMemoryUsage();
+        Log() << "Mem usage: physical " << QString::number(mem0.phys / 1024.0, 'f', 1)
+              << " KiB, virtual " << QString::number(mem0.virt / 1024.0, 'f', 1) << " KiB";
+
+
+        auto mpd = loadMempoolDat(mpdat);
+
+        Mempool mempool;
+        {
+            static const Mempool::GetTXOInfoFromDBFunc getTXOInfo = [](const TXO &txo) -> std::optional<TXOInfo> {
+                TXOInfo ret;
+                ret.amount = 546 * bitcoin::Amount::satoshi();
+                ret.confirmedHeight = 1;
+                ret.hashX = BTC::HashXFromCScript(bitcoin::CScript() << Util::toVec<std::vector<uint8_t>>(txo.toBytes()));
+                return ret;
+            };
+            Mempool::ScriptHashesAffectedSet shset;
+            const auto t0 = Util::getTimeMicros();
+            const auto stats = mempool.addNewTxs(shset, mpd, getTXOInfo);
+            const auto tf = Util::getTimeMicros();
+            mpd.clear();
+            Log() << "Added to mempool in " << QString::number((tf-t0)/1e3, 'f', 3) << " msec."
+                  << " Scripthashes: " << shset.size() << ", size: " << stats.newSize << ", addresses " << stats.newNumAddresses;
+            shset.clear();
+            const auto mem = Util::getProcessMemoryUsage();
+            Log() << "Mem usage: physical " << QString::number(mem.phys / 1024.0, 'f', 1)
+                  << " KiB, virtual " << QString::number(mem.virt / 1024.0, 'f', 1) << " KiB";
+            Log() << "Delta phys: " << QString::number((mem.phys - mem0.phys) / 1024.0, 'f', 1) << " KiB";
+        }
+
+        Log() << "-------------------------------------------------------------------------------";
+
+        {
+            const auto t0 = Util::getTimeMicros();
+            // iterate each time, dropping leaves from mempool
+            for (int ct = 1; !mempool.txs.empty(); ++ct) {
+                Mempool::TxHashSet txids;
+                for (const auto & [txHash, tx] : mempool.txs) {
+                    std::unordered_set<IONum> ionums;
+                    for (const auto & [hashX, ioinfo] : tx->hashXs) {
+                        for (const auto & n : ioinfo.utxo)
+                            ionums.insert(n);
+                    }
+                    std::size_t validSize = 0;
+                    for (const auto & txo : tx->txos)
+                        validSize += txo.isValid();
+                    if (ionums.size() == validSize) {
+                        // this is a leaf
+                        txids.insert(txHash);
+                        // do at most 1000 drops each iter
+                        if (txids.size() >= 1000)
+                            break;
+                    }
+                }
+                if (txids.empty())
+                    throw InternalError("Expected to find at least 1 leaf tx! This should not happen! FIXME!");
+                Mempool::ScriptHashesAffectedSet shset;
+                //Debug::forceEnable = true;
+                const auto t1 = Util::getTimeMicros();
+                const auto stats = mempool.dropTxs(shset, txids, true);
+                const auto t2 = Util::getTimeMicros();
+                Log() << "Iter: " << ct << " oldSize: " << stats.oldSize << " newSize: " << stats.newSize
+                      << " oldNumAddresses: " << stats.oldNumAddresses << " newNumAddresses: " << stats.newNumAddresses
+                      << " shsaffected: " << shset.size() << " in " << QString::number((t2-t1)/1e3, 'f', 1) << " msec";
+            }
+            const auto tf = Util::getTimeMicros();
+            Log() << "Dropped all from mempool in " << QString::number((tf-t0)/1e3, 'f', 3) << " msec.";
+            const auto mem = Util::getProcessMemoryUsage();
+            Log() << "Mem usage: physical " << QString::number(mem.phys / 1024.0, 'f', 1)
+                  << " KiB, virtual " << QString::number(mem.virt / 1024.0, 'f', 1) << " KiB";
+        }
+    }
+
+    static const auto bench_ = App::registerBench("mempool", &bench);
+}
+#endif

--- a/src/Mempool.cpp
+++ b/src/Mempool.cpp
@@ -447,7 +447,7 @@ namespace {
             uint64_t version;
             file >> version;
             constexpr uint64_t BCHN_BTC_VERSION = 1, BU_VERSION = 1541030400;
-            if (!std::set{{BCHN_BTC_VERSION, BU_VERSION}}.count(version))
+            if (!std::set<uint64_t>({BCHN_BTC_VERSION, BU_VERSION}).count(version))
                 throw Exception(QString("Unknown mempool.dat version: %1").arg(qulonglong(version)));
 
             uint64_t num;

--- a/src/Mempool.cpp
+++ b/src/Mempool.cpp
@@ -221,7 +221,7 @@ auto Mempool::dropTxs(ScriptHashesAffectedSet & scriptHashesAffectedOut, const T
                             // this spends one of the ones in our set! add it since it's a child of something we want to remove.
                             txids.emplace(txid);
                             ++added;
-                            DebugM("addBlock: additonal tx ", Util::ToHexFast(txid), " added to set because it spends ",
+                            DebugM("dropTxs: additonal tx ", Util::ToHexFast(txid), " added to set because it spends ",
                                    txo.toString(), " which is already in our removal set");
                             goto outer_loop_iterate_again;
                         }

--- a/src/Mempool.cpp
+++ b/src/Mempool.cpp
@@ -207,8 +207,8 @@ auto Mempool::dropTxs(ScriptHashesAffectedSet & scriptHashesAffectedOut, const T
             for (const auto & [txid, tx] : txs) {
                 if (!tx->hasUnconfirmedParentTx || txids.count(txid))
                     continue; // no unconf. parents or already added
-                for (const auto &[sh, ioinfo] : tx->hashXs) {
-                    for (const auto &[txo, txoinfo] : ioinfo.unconfirmedSpends) {
+                for (const auto & [sh, ioinfo] : tx->hashXs) {
+                    for (const auto & [txo, txoinfo] : ioinfo.unconfirmedSpends) {
                         if (txids.count(txo.txHash)) {
                             // this spends one of the ones in our set! add it since it's a child of something we want to remove.
                             txids.emplace(txid);

--- a/src/Mempool.h
+++ b/src/Mempool.h
@@ -24,6 +24,8 @@
 #include "bitcoin/amount.h"
 #include "robin_hood/robin_hood.h"
 
+#include <QVariantMap>
+
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
@@ -172,4 +174,9 @@ struct Mempool
     /// mempool takes under 1 ms on average hardware, so it's very fast. Storage calls this in refreshMempoolHistogram
     /// from a periodic background task kicked off in Controller.
     FeeHistogramVec calcCompactFeeHistogram(double binSize = 1e5 /* binSize in bytes */) const;
+
+    // -- Dump (for JSONesque debug support)
+
+    /// Dump to QVariantMap (used by Controller::debug(), see Controller.cpp)
+    QVariantMap dump() const;
 };

--- a/src/Mempool.h
+++ b/src/Mempool.h
@@ -174,10 +174,11 @@ struct Mempool
     /// dropTxs() implicitly calls this.
     std::size_t growTxHashSetToIncludeDescendants(TxHashSet &txids, bool TRACE = false) const;
 
-protected:
-    // Disallow clears from external code. Client code should always just use dropTxs.
+    /// Note: clearing the mempool is only done on block undo. Client code should in general just use dropTxs().
     void clear();
 
-    // Implementation of same-named function
+protected:
+
+    // Actual implementation of same-named function
     std::size_t growTxHashSetToIncludeDescendants(const char *const logprefix, TxHashSet &txids, bool TRACE) const;
 };

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1282,7 +1282,7 @@ void Storage::addBlock(PreProcessedBlockPtr ppb, bool saveUndo, unsigned nReserv
         txids.reserve(sz > 0 ? sz-1 : 0);
         for (std::size_t i = 1 /* skip coinbase */; i < sz; ++i)
             txids.insert(ppb->txInfos[i].hash);
-        const auto res = p->mempool.dropTxs(*notify, txids, Trace::isEnabled());
+        const auto res = p->mempool.dropTxs(*notify, txids, Trace::isEnabled(), 0.5f /* shrink to fit load_factor threshold */);
         if (const auto diff = res.oldSize - res.newSize; diff && Debug::isEnabled()) {
             Debug() << "addBlock: removed " << diff << " txs from mempool involving "
                     << (res.oldNumAddresses-res.newNumAddresses) << " addresses";

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -65,7 +65,6 @@ struct UndoInfoMissing : public Exception { using Exception::Exception; ~UndoInf
 /// Thrown by internally by getHistory and listUnspent if the history is too large (larger than max_history from config).
 struct HistoryTooLarge : public Exception { using Exception::Exception; ~HistoryTooLarge() override; };
 
-struct Mempool;
 class SubsMgr;
 
 /// Manages the db and all storage-related facilities.  Most of its public methods are fully reentrant and thread-safe.

--- a/src/TXO.h
+++ b/src/TXO.h
@@ -33,6 +33,7 @@
 #include <cstring> // for std::memcpy
 #include <functional> // for std::hash
 #include <optional>
+#include <tuple> // for std::tie
 
 /// A transaction output; A txHash:outN pair.
 struct TXO {
@@ -43,7 +44,7 @@ struct TXO {
     QString toString() const;
 
     bool operator==(const TXO &o) const noexcept { return txHash == o.txHash && outN == o.outN; }
-    bool operator<(const TXO &o) const noexcept { return txHash < o.txHash && outN < o.outN; }
+    bool operator<(const TXO &o) const noexcept { return std::tie(txHash, outN) < std::tie(o.txHash, o.outN); }
 
 
     // serialization/deserialization

--- a/src/TXO.h
+++ b/src/TXO.h
@@ -101,6 +101,7 @@ struct TXOInfo {
     /// for debug, etc
     bool operator==(const TXOInfo &o) const
         { return amount == o.amount && hashX == o.hashX && confirmedHeight == o.confirmedHeight && txNum == o.txNum; }
+    bool operator!=(const TXOInfo &o) const { return !(*this == o); }
 
     QByteArray toBytes() const noexcept {
         QByteArray ret;

--- a/src/bitcoin/amount.cpp
+++ b/src/bitcoin/amount.cpp
@@ -8,13 +8,31 @@
 
 #include "tinyformat.h"
 
+#include <shared_mutex>
+
 namespace bitcoin {
 
-const std::string CURRENCY_UNIT = "BCH";
+// added by Calin
+namespace {
+std::string mutableCurrencyUnit = "BCH";
+std::shared_mutex currencyUnitMut;
+}
+void SetCurrencyUnit(const std::string &unit) {
+    std::unique_lock g(currencyUnitMut);
+    mutableCurrencyUnit = unit;
+}
+std::string GetCurrencyUnit() {
+    std::shared_lock g(currencyUnitMut);
+    return mutableCurrencyUnit;
+}
+// /added by Calin
 
 std::string Amount::ToString() const {
-    return strprintf("%d.%08d %s", *this / COIN, (*this % COIN) / SATOSHI,
-                     CURRENCY_UNIT);
+    // Modified by Calin to properly handle negative values
+    const bool negative = *this < Amount::zero();
+    const Amount absVal = negative ? -1 * *this : *this;
+    return strprintf("%s%d.%08d %s", negative ? "-" : "", absVal / COIN, (absVal % COIN) / SATOSHI,
+                     GetCurrencyUnit());
 }
 
 } // end namespace bitcoin

--- a/src/bitcoin/amount.h
+++ b/src/bitcoin/amount.h
@@ -147,7 +147,8 @@ static constexpr Amount CASH = 100 * SATOSHI;
 static constexpr Amount COIN = 100000000 * SATOSHI;
 static constexpr Amount CENT = COIN / 100;
 
-extern const std::string CURRENCY_UNIT;
+void SetCurrencyUnit(const std::string &); // added by Calin to allow for also supporting BTC -- this is thread-safe (uses rw-locks)
+std::string GetCurrencyUnit(); // added by Calin to allow for also supporting BTC -- this is thread-safe (uses rw-locks)
 
 /**
  * No amount larger than this (in satoshi) is valid.

--- a/src/bitcoin/feerate.cpp
+++ b/src/bitcoin/feerate.cpp
@@ -58,6 +58,6 @@ Amount CFeeRate::GetFeeCeiling(size_t nBytes) const {
 
 std::string CFeeRate::ToString() const {
     return strprintf("%d.%08d %s/kB", nSatoshisPerK / COIN,
-                     (nSatoshisPerK % COIN) / SATOSHI, CURRENCY_UNIT);
+                     (nSatoshisPerK % COIN) / SATOSHI, GetCurrencyUnit());
 }
 } // end namespace bitcoin

--- a/src/bitcoin/transaction.cpp
+++ b/src/bitcoin/transaction.cpp
@@ -162,8 +162,8 @@ size_t CTransaction::GetBillableSize() const {
     return bitcoin::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
 }
 
-unsigned int CTransaction::GetTotalSize() const {
-    return bitcoin::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
+unsigned int CTransaction::GetTotalSize(bool segwit) const {
+    return bitcoin::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION | (segwit ? SERIALIZE_TRANSACTION_USE_WITNESS : 0));
 }
 
 std::string CTransaction::ToString() const {

--- a/src/bitcoin/transaction.h
+++ b/src/bitcoin/transaction.h
@@ -418,7 +418,7 @@ public:
      * Get the total transaction size in bytes.
      * @return Total transaction size in bytes
      */
-    unsigned int GetTotalSize() const;
+    unsigned int GetTotalSize(bool segwit = false) const;
 
     bool IsCoinBase() const {
         return (vin.size() == 1 && vin[0].prevout.IsNull());


### PR DESCRIPTION
This massively refactors the `SynchMempoolTask` and the `Mempool` class to 
support dropping txs in a more performant manner.  Gone are the days of 
necessitating a full mempool re-download when a single tx is dropped.  Instead,
we now undo the effects of a mempool tx when dropping.  Note that dropping a tx
implicitly drops all of its descendant txs as well.  In practice this is an ok
limitation.

This change is particularly important for supporting BTC, which frequntly has 
single tx's replaced by RBF double-spends.

Also congested mempools (such as was seen recently on ABC chain) should do
much better now since we don't have to rebuild the whole mempool each time
for a single dropped tx.

Also in this change: 

- Bumped version to 1.3.2
- Fixed a bug where the TXO type had a broken `operator<` (this operator was
thankfully never called)
- Added a "mempool" bench (which is really more of a test).  This test heavily
tests the new `dtopTxs` call to ensure it is sane.
- Various small bits and bits of refactoring.

 