### PR TITLE
Implemented confirmedInBlock; plus other fixups and refactoring

### DIFF
--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -79,7 +79,7 @@ DEFINES += USE_QT_IN_BITCOIN
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 # If defined, tests and benchmarks will be compiled-in to the app (accessed via --test and --bench CLI args).
-#DEFINES += ENABLE_TESTS
+DEFINES += ENABLE_TESTS
 
 win32-msvc {
     error("MSVC is not supported for this project. Please compile with MinGW G++ 7.3.0 or above.")

--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -79,7 +79,7 @@ DEFINES += USE_QT_IN_BITCOIN
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 # If defined, tests and benchmarks will be compiled-in to the app (accessed via --test and --bench CLI args).
-DEFINES += ENABLE_TESTS
+#DEFINES += ENABLE_TESTS
 
 win32-msvc {
     error("MSVC is not supported for this project. Please compile with MinGW G++ 7.3.0 or above.")

--- a/src/Mempool.cpp
+++ b/src/Mempool.cpp
@@ -455,8 +455,8 @@ auto Mempool::confirmedInBlock(ScriptHashesAffectedSet & scriptHashesAffectedOut
                         // transfer from unconfirmed spends -> confirmed spends
                         ioinfo.confirmedSpends.insert(ioinfo.unconfirmedSpends.extract(it2move)); // does not invalidate refs
                         ++ctr;
-                        // TODO: remove this when debugging done
-                        DebugM("confirmedInBlock: TXO ", txo.toString(), " now recategorized under \"confirmedSpends\" for txid ", tx->hash.toHex());
+                        if (TRACE)
+                            DebugM("confirmedInBlock: TXO ", txo.toString(), " now recategorized under \"confirmedSpends\" for txid ", tx->hash.toHex());
                     } else
                         // prevout txid not in rm set, keep moving
                         ++itUS;
@@ -468,8 +468,8 @@ auto Mempool::confirmedInBlock(ScriptHashesAffectedSet & scriptHashesAffectedOut
                     scriptHashesAffected.insert(sh);
                     // and also flag it as needing sort because its sorting criteria changed
                     hashXTxsEntriesNeedingSort->insert(sh);
-                    // TODO: remove this when debugging done
-                    DebugM("confirmedInBlock: txid ", tx->hash.toHex(), " now recategorized as not spending any unconfirmed parents");
+                    if (TRACE)
+                        DebugM("confirmedInBlock: txid ", tx->hash.toHex(), " now recategorized as not spending any unconfirmed parents");
                 }
             }
         }

--- a/src/Mempool.cpp
+++ b/src/Mempool.cpp
@@ -367,7 +367,7 @@ std::size_t Mempool::rmTxsInHashXTxs(const TxHashSet &txids, const ScriptHashesA
 {
     Tic t0;
     std::size_t ct = 0, sortCt = 0;
-    qint64 sortTimeMicros = 0;
+    qint64 sortTimeNanos = 0;
 
     // next, scan hashXs, removing entries for the txids in question
     for (const auto & hashX : scriptHashesAffected) {
@@ -408,12 +408,12 @@ std::size_t Mempool::rmTxsInHashXTxs(const TxHashSet &txids, const ScriptHashesA
             Tic t1;
             std::sort(txvec.begin(), txvec.end(), Mempool::TxRefOrdering{});
             ++sortCt;
-            sortTimeMicros += t1.usec();
+            sortTimeNanos += t1.nsec();
         }
     }
     DebugM("rmTxsInHashXTxs: removed ", ct, " entries in ", t0.msecStr(), " msec",
            (sortCt ? QString(" sorted %1 entries").arg(sortCt) : ""),
-           (sortTimeMicros ? QString(" (sort time: %1 msec)").arg(QString::number(sortTimeMicros/1e3, 'f', 3)) : ""));
+           (sortTimeNanos ? QString(" (sort time: %1 msec)").arg(QString::number(sortTimeNanos/1e6, 'f', 3)) : ""));
     return ct;
 }
 

--- a/src/Mempool.cpp
+++ b/src/Mempool.cpp
@@ -163,7 +163,7 @@ auto Mempool::addNewTxs(ScriptHashesAffectedSet & scriptHashesAffected,
                     sh = prevInfo.hashX = hxit->first;
                 } else {
                     // new entry, insert, update hxit
-                    auto pair = tx->hashXs.insert({sh, decltype(hxit->second)()});
+                    auto pair = tx->hashXs.emplace(std::piecewise_construct, std::forward_as_tuple(sh), std::forward_as_tuple());
                     hxit = pair.first;
                 }
                 // end memory saving hack
@@ -263,6 +263,7 @@ auto Mempool::dropTxs(ScriptHashesAffectedSet & scriptHashesAffectedOut, const T
 
     Stats ret;
     ScriptHashesAffectedSet scriptHashesAffected;
+    int skipPrevCt = 0;
     auto & [oldSize, newSize, oldNumAddresses, newNumAddresses, elapsedMsec] = ret;
     oldSize = this->txs.size();
     oldNumAddresses = this->hashXTxs.size();
@@ -271,18 +272,26 @@ auto Mempool::dropTxs(ScriptHashesAffectedSet & scriptHashesAffectedOut, const T
     for (const auto & txid : txids) {
         auto it = txs.find(txid);
         if (UNLIKELY(it == txs.end())) {
-            // Note that it's ok to call this function for non-existant tx's -- we call it when adding new blocks
-            // and it's possible for txids in blocks to not be in mempool. Only print a message in debug mode.
+            // Note that it's ok to call this function for non-existant tx's -- if we call it when adding new blocks
+            // then it's possible for txids in blocks to not be in mempool. Only print a message in debug mode.
             DebugM("dropTxs: tx ", Util::ToHexFast(txid), " not found in mempool");
             continue;
         }
         auto & tx = it->second;
         // for each hashX this tx affects, look for unconfirmed spends
         for (const auto & [hashX, ioinfo]: tx->hashXs) {
-            scriptHashesAffected.insert(hashX); // update affected set with all addresses for this tx
-            // for each unconfirmed spend, go to the previous tx in mempool and add back the utxo to ioinfo.utxo for the parent tx hashx entry
+            // update affected set with all addresses involved with this tx (spends, outs, etc)
+            scriptHashesAffected.insert(hashX);
+            // for each unconfirmed spend, go to the previous tx in mempool and add back the utxo to ioinfo.utxo
+            // for the parent tx hashx entry
             for (const auto & [txo, txoinfo] : ioinfo.unconfirmedSpends) {
-                scriptHashesAffected.insert(txoinfo.hashX); // updated affected set with address of txo we spent as well
+                assert(txoinfo.hashX == hashX);
+                if (txids.count(txo.txHash)) {
+                    // prev tx will be (or has already been) removed, no sense in doing any utxo crediting for a tx
+                    // that will disappear shortly
+                    ++skipPrevCt;
+                    continue;
+                }
                 auto prevIt = txs.find(txo.txHash);
                 if (LIKELY(prevIt != txs.end())) {
                     auto & prevTx = prevIt->second;
@@ -323,13 +332,48 @@ auto Mempool::dropTxs(ScriptHashesAffectedSet & scriptHashesAffectedOut, const T
                 }
             }
         }
+
+        // and finally remove this tx from `txs` now, while we have its iterator .. this is faster
+        // than doing the remove later, since we already have the iterator now!
+        txs.erase(it);
     }
+
+    if (skipPrevCt)
+        DebugM("dropTxs: previous tx \"crediting\" skipped due to being in drop set: ", skipPrevCt);
+
+    // next, scan hashXs, removing entries for the txids in question
+    // -- note this helper function doesn't look at `txs` so it's fine that we removed already in the loop above.
+    rmTxsInHashXTxs(txids, scriptHashesAffected, TRACE);
+
+    // finally, update scriptHashesAffectedOut
+    scriptHashesAffectedOut.merge(std::move(scriptHashesAffected));
+
+    // update returned stats
+    newSize = this->txs.size();
+    newNumAddresses = this->hashXTxs.size();
+
+    if (rehashMaxLoadFactor) {
+        if (txs.load_factor() <= *rehashMaxLoadFactor)
+            txs.rehash(0); // shrink to fit
+        if (hashXTxs.load_factor() <= *rehashMaxLoadFactor)
+            hashXTxs.rehash(0);  // shrink to fit
+    }
+    elapsedMsec = t0.msec<decltype(elapsedMsec)>();
+    return ret;
+}
+
+std::size_t Mempool::rmTxsInHashXTxs(const TxHashSet &txids, const ScriptHashesAffectedSet &scriptHashesAffected, const bool TRACE,
+                                     const std::optional<ScriptHashesAffectedSet> &hashXsNeedingSort)
+{
+    Tic t0;
+    std::size_t ct = 0, sortCt = 0;
+    qint64 sortTimeMicros = 0;
 
     // next, scan hashXs, removing entries for the txids in question
     for (const auto & hashX : scriptHashesAffected) {
         auto it = hashXTxs.find(hashX);
         if (UNLIKELY(it == hashXTxs.end())) {
-            Warning() << "dtopTxs: Could not find hashX " << hashX.toHex() << " in hashXTxs map! FIXME!";
+            Warning() << "rmTxsInHashXTxs: Could not find hashX " << hashX.toHex() << " in hashXTxs map! FIXME!";
             continue;
         }
         auto & txvec = it->second;
@@ -340,31 +384,103 @@ auto Mempool::dropTxs(ScriptHashesAffectedSet & scriptHashesAffectedOut, const T
             if (txids.count(txref->hash) == 0)
                 // not in txid set; copy it to newvec
                 newvec.push_back(txref);
+            else
+                ++ct; // will be removed, tally count
         }
         if (!newvec.empty() && newvec.size() != txvec.size()) {
             // swap the vectors with the one not containing the affected txids
             if (TRACE) {
                 const auto oldsz = txvec.size(), newsz = newvec.size();
                 if (TRACE)
-                    Debug() << "dropTxs: Shrunk hashX " << Util::ToHexFast(hashX) << " txvec from size " << oldsz
+                    Debug() << "rmTxsInHashXTxs: Shrunk hashX " << Util::ToHexFast(hashX) << " txvec from size " << oldsz
                             << " to size " << newsz;
             }
             txvec.swap(newvec);
             txvec.shrink_to_fit();
-        } else if (newvec.empty()){
+        } else if (newvec.empty()) {
             // if the new vector is empty meaning this hashX should disappear from the hashXTxs map!
             hashXTxs.erase(it);
-            if (TRACE) Debug() << "dropTxs: Removed hashX " << Util::ToHexFast(hashX) << " which now has no txs in mempool";
+            if (TRACE) Debug() << "rmTxsInHashXTxs: Removed hashX " << Util::ToHexFast(hashX) << " which now has no txs in mempool";
+            continue; // removed; ensure we skip the below potential sort
+        }
+        // if sorting specified, sort if in set (and if not removed 2 lines above)
+        if (hashXsNeedingSort && hashXsNeedingSort->count(hashX)) {
+            Tic t1;
+            std::sort(txvec.begin(), txvec.end(), Mempool::TxRefOrdering{});
+            ++sortCt;
+            sortTimeMicros += t1.usec();
         }
     }
+    DebugM("rmTxsInHashXTxs: removed ", ct, " entries in ", t0.msecStr(), " msec",
+           (sortCt ? QString(" sorted %1 entries").arg(sortCt) : ""),
+           (sortTimeMicros ? QString(" (sort time: %1 msec)").arg(QString::number(sortTimeMicros/1e3, 'f', 3)) : ""));
+    return ct;
+}
 
-    // next, erase the txid's in question from the txs map
-    for (const auto & txid : txids) {
-        txs.erase(txid);
+auto Mempool::confirmedInBlock(ScriptHashesAffectedSet & scriptHashesAffectedOut, const TxHashSet & txids, bool TRACE,
+                               std::optional<float> rehashMaxLoadFactor) -> Stats
+{
+    const auto t0 = Tic();
+
+    Stats ret;
+    ScriptHashesAffectedSet scriptHashesAffected;
+    std::optional<ScriptHashesAffectedSet> hashXTxsEntriesNeedingSort;
+    hashXTxsEntriesNeedingSort.emplace();
+    auto & [oldSize, newSize, oldNumAddresses, newNumAddresses, elapsedMsec] = ret;
+    oldSize = this->txs.size();
+    oldNumAddresses = this->hashXTxs.size();
+
+    // iterate through all txs in mempool
+    for (auto itTxs = txs.begin(); itTxs != txs.end(); /* may delete during iteration, see below */) {
+        const auto & [txid, tx] = *itTxs; // take refs for convenience (note they are invalidated after if erase(itTxs) )
+        const bool inRmSet = txids.count(txid);
+        if (inRmSet) {
+            // this txid is to be removed from mempool, tally its scripthashes as affected by the removal
+            for (const auto & [sh, _] : tx->hashXs)
+                scriptHashesAffected.insert(sh);
+            // and erase NOW!
+            itTxs = txs.erase(itTxs); // in this branch: removed, take next it and continue
+            continue;
+        } else if (tx->hasUnconfirmedParentTx) {
+            // This txid is *not* to be removed, but MAY possibly be spending from a tx we are going to remove.
+            // Scan all of its unconfirmed spends to see if they spend from a tx in the removal set, and if so,
+            // recategorize those spends as confirmed spends.
+            for (auto & [sh, ioinfo] : tx->hashXs) {
+                int ctr = 0;
+                for (auto itUS = ioinfo.unconfirmedSpends.begin(); itUS != ioinfo.unconfirmedSpends.end(); /* see below */) {
+                    const auto & [txo, _] = *itUS; // take refs for readibility below
+                    if (txids.count(txo.txHash)) {
+                        // and voila! This tx spends from one of the tx's we are going to remove. Recategorize unconf -> conf.
+                        auto it2move = itUS++;  // first make `it` point to `it` + 1, making `it2move` be previous value `it`
+                        // transfer from unconfirmed spends -> confirmed spends
+                        ioinfo.confirmedSpends.insert(ioinfo.unconfirmedSpends.extract(it2move)); // does not invalidate refs
+                        ++ctr;
+                        // TODO: remove this when debugging done
+                        DebugM("confirmedInBlock: TXO ", txo.toString(), " now recategorized under \"confirmedSpends\" for txid ", tx->hash.toHex());
+                    } else
+                        // prevout txid not in rm set, keep moving
+                        ++itUS;
+                }
+                // no more unconf spends now for this tx, reset flag
+                if (ctr && ioinfo.unconfirmedSpends.empty()) {
+                    tx->hasUnconfirmedParentTx = false;
+                    // and also need to add to affected set since clients use the "height" info for this tx which went from -1 -> 0 now.
+                    scriptHashesAffected.insert(sh);
+                    // and also flag it as needing sort because its sorting criteria changed
+                    hashXTxsEntriesNeedingSort->insert(sh);
+                    // TODO: remove this when debugging done
+                    DebugM("confirmedInBlock: txid ", tx->hash.toHex(), " now recategorized as not spending any unconfirmed parents");
+                }
+            }
+        }
+        ++itTxs; // in this branch: nothing removed, keep iterating
     }
 
+    // now, update hashXTxs as well
+    rmTxsInHashXTxs(txids, scriptHashesAffected, TRACE, hashXTxsEntriesNeedingSort);
+
     // finally, update scriptHashesAffectedOut
-    scriptHashesAffectedOut.merge(scriptHashesAffected);
+    scriptHashesAffectedOut.merge(std::move(scriptHashesAffected));
 
     // update returned stats
     newSize = this->txs.size();

--- a/src/Mempool.h
+++ b/src/Mempool.h
@@ -163,7 +163,7 @@ struct Mempool
     /// searched for recursively.  Normally when this is called, it's for RBF or full mempool eviction, and such tx's
     /// always drop out as an entire set if in a chain (so this aforementioned perf. penralty is not normally paid).
     ///
-    /// Why is the penalty?  This is because descendant tx's not appearing in `txids` must be removed since they are
+    /// Why the penalty?  This is because descendant tx's not appearing in `txids` must be removed since they are
     /// txs that no longer are spending valid inputs (as far as this Mempool instance is aware of, at least).
     Stats dropTxs(ScriptHashesAffectedSet & scriptHashesAffected, const TxHashSet & txids, bool TRACE = false,
                   std::optional<float> rehashMaxLoadFactor = {});

--- a/src/Mempool.h
+++ b/src/Mempool.h
@@ -102,7 +102,7 @@ struct Mempool
     /// ensures an ordering of TxRefs for the set below that are from fewest ancestors -> most ancestors
     struct TxRefOrdering {
         bool operator()(const TxRef &a, const TxRef &b) const {
-            if (a && b) {
+            if (LIKELY(a && b)) {
                 if (UNLIKELY(a == b))
                     return false;
                 return *a < *b;
@@ -114,7 +114,7 @@ struct Mempool
     };
     /// Note: The TxRefs here here point to the same object as the mapped_type in the TxMap above
     /// Note that while the mapped_type is a vector, it is guaranteed to contain unique TxRefs, ordered by
-    /// TxRefOrdering above.  This invariant is maintained in Controller.cpp, SynchMempoolTask::processResults().
+    /// TxRefOrdering above.  This invariant is maintained in addTxs() as well as confirmedInBlock().
     using HashXTxMap = robin_hood::unordered_node_map<HashX, std::vector<TxRef>, HashHasher>;
 
 
@@ -139,7 +139,8 @@ struct Mempool
         double elapsedMsec = 0.;
     };
 
-    /// Add a batch of tx's that are new (downloaded from bitcoind) and were not previously in this mempool structure
+    /// Add a batch of tx's that are new (downloaded from bitcoind) and were not previously in this mempool structure.
+    ///
     /// Note that all the txs in txsNew *must* be new (must not already exist in this mempool instance).
     /// scriptHashesAffected is updated for all of the new tx's added.
     /// This is called by the SynchMempoolTask in Controller.cpp.
@@ -151,18 +152,30 @@ struct Mempool
 
     // -- Drop from mempool
 
-    using TxHashSet = std::unordered_set<TxHash, HashHasher>;
+    using TxHashSet = std::unordered_set<TxHash, HashHasher>; ///< Used below by dropTxs() & confirmedInBlock()
+
     /// Drop a bunch of tx's, deleting them from this data structure and reversing the effects of their spends
-    /// in the mempool. This is called by the SynchMempoolTask whenever the bitcoind mempool has droped tx's.
-    /// Note that this function executes much faster if the caller is not dropping any tx's in the middle of an
-    /// unconfirmed chain.  This is because descendant txs not in `txids` but that spend from txs in `txids` will
-    /// also be removed, and they must be searched for recursively.
+    /// in the mempool.
     ///
-    /// Why is this?  This is because descendant tx's not appearing in `txids` must be removed since they are txs that
-    /// no longer are spending valid inputs (as far as this Mempool instance is concerned at least).
+    /// This is called by the SynchMempoolTask whenever the bitcoind mempool has droped tx's. Note that this function
+    /// executes much faster if the caller is not dropping any tx's in the middle of an unconfirmed chain.  This is
+    /// because descendant txs not in `txids` but that spend from txs in `txids` will also be removed, and they must be
+    /// searched for recursively.  Normally when this is called, it's for RBF or full mempool eviction, and such tx's
+    /// always drop out as an entire set if in a chain (so this aforementioned perf. penralty is not normally paid).
+    ///
+    /// Why is the penalty?  This is because descendant tx's not appearing in `txids` must be removed since they are
+    /// txs that no longer are spending valid inputs (as far as this Mempool instance is aware of, at least).
     Stats dropTxs(ScriptHashesAffectedSet & scriptHashesAffected, const TxHashSet & txids, bool TRACE = false,
                   std::optional<float> rehashMaxLoadFactor = {});
 
+
+    /// Called by Storage::addBlock -- removes the txids in question, and also reassigns any txs spending them to
+    /// "confirmed spends".
+    ///
+    /// Note this is like dropTxs but doesn't drop child txs, just reassigns their spends. *Only* call this during
+    /// block processing when you know for a fact that the txids in `txids` are now confirmed!
+    Stats confirmedInBlock(ScriptHashesAffectedSet & scriptHashesAffected, const TxHashSet & txids, bool TRACE = false,
+                           std::optional<float> rehashMaxLoadFactor = {});
 
     // -- Fee histogram support (used by mempool.get_fee_histogram RPC) --
 
@@ -184,18 +197,22 @@ struct Mempool
 
     // -- Misc. utility
 
-    /// Note: clearing the mempool is only done on block undo. Client code should in general just use dropTxs().
+    /// Note: clearing the mempool is only done on block undo. Client code should in general just use dropTxs() and/or
+    /// confirmedInBlock().
     void clear();
 
-protected:
+private:
     /// Given a set of txids in this Mempool, grow the set to encompass all descendant tx's that spend
-    /// from the initial set.  Will keep iterating until it cennot grow the set any longer.
+    /// from the initial set.  Will keep iterating until it cannot grow the set any longer.
     /// dropTxs() implicitly calls this.
     std::size_t growTxHashSetToIncludeDescendants(TxHashSet &txids, bool TRACE = false) const;
 
-
-    // Actual implementation of same-named function
+    /// Actual implementation of same-named function
     std::size_t growTxHashSetToIncludeDescendants(const char *const logprefix, TxHashSet &txids, bool TRACE) const;
+
+    /// Internal use; called by dropTxs and confirmedInBlock to do some book-keeping; returns number of txs removed.
+    std::size_t rmTxsInHashXTxs(const TxHashSet &txids, const ScriptHashesAffectedSet &scriptHashesAffected, bool TRACE,
+                                const std::optional<ScriptHashesAffectedSet> &hashXsNeedingSort = {});
 
 #ifdef ENABLE_TESTS
 public:


### PR DESCRIPTION
This further optimizes processing for full mempools. In the `addBlock()`
execution path, we were removing too many tx's before.  Instead, now we
remove just the ones in the block and not their descendants.  For
descendants, we recategorize the spends as "confirmed spends" for txids
that are now in the new freshly-confirmed block.