### PR TITLE
fixed arithmetic expansion

### DIFF
--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -16,4 +16,4 @@ fi
 # If CPU_COUNT is still unset, default to 4
 export CPU_COUNT="${CPU_COUNT:-4}"
 # Use one more worker than core count
-export WORKER_COUNT=$[$CPU_COUNT+1]
+export WORKER_COUNT=$(($CPU_COUNT+1))


### PR DESCRIPTION
Build failed on my Debian Buster machine, because WORKER_COUNT was assigned a string of $CPU_COUNT+1