### PR TITLE
Allow for >65535 TXO IONums

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -423,7 +423,8 @@ void App::parseArgs()
     },
     { { "C", "checkdb" },
        QString("If specified, database consistency will be checked thoroughly for sanity & integrity."
-               " Note that these checks are somewhat slow to perform and under normal operation are not necessary.\n"),
+               " Note that these checks are somewhat slow to perform and under normal operation are not necessary."
+               " May be specified twice to do even more thorough checks.\n"),
     },
     { { "T", "polltime" },
        QString("The number of seconds for the bitcoind poll interval. Bitcoind is polled once every `polltime`"
@@ -596,7 +597,12 @@ void App::parseArgs()
     }
     if (parser.isSet("q") || conf.boolValue("quiet")) options->verboseDebug = false;
     if (parser.isSet("S") || conf.boolValue("syslog")) options->syslogMode = true;
-    if (parser.isSet("C") || conf.boolValue("checkdb")) options->doSlowDbChecks = true;
+    if (const auto pset = parser.isSet("C"); pset || conf.boolValue("checkdb")) {
+        if (pset)
+            options->doSlowDbChecks = parser.optionNames().count("C");
+        else
+            options->doSlowDbChecks = conf.values("checkdb").size();
+    }
     // parse --polltime
     // note despite how confusingly the below line reads, the CLI parser value takes precedence over the conf file here.
     const QString polltimeStr = conf.value("polltime", parser.value("T"));

--- a/src/BlockProcTypes.h
+++ b/src/BlockProcTypes.h
@@ -25,11 +25,16 @@
 
 #include <QByteArray>
 
+#include <limits>
+
 using HashHasher = BTC::QByteArrayHashHasher;
 
 using BlockHeight = std::uint32_t;
 using TxNum = std::uint64_t; ///< this is used by the storage subsystem and also CompactTXO
-using IONum = std::uint16_t;
+using IONum = std::uint32_t;
+inline constexpr IONum IONum16Max = std::numeric_limits<std::uint16_t>::max(); ///< IONums beyond this value get serialized as 3 bytes
+inline constexpr IONum IONumMax = (IONum(0x1) << 24) - 1; ///< support up to 24-bit IONum
+inline constexpr TxNum TxNumMax = (TxNum(0x1) << 48) - 1; ///< support up to 48-bit TxNum
 using TxHash = QByteArray;
 using HashX = QByteArray; ///< Note that despite the name, unlike in ElectrumX/ElectronX, our "HashX" is always the full 32-byte sha256 hash.
 using BlockHash = QByteArray;

--- a/src/Mempool.cpp
+++ b/src/Mempool.cpp
@@ -732,7 +732,7 @@ namespace {
                 TXOInfo ret;
                 ret.amount = 546 * bitcoin::Amount::satoshi();
                 ret.confirmedHeight = 1;
-                ret.hashX = BTC::HashXFromCScript(bitcoin::CScript() << Util::toVec<std::vector<uint8_t>>(txo.toBytes()));
+                ret.hashX = BTC::HashXFromCScript(bitcoin::CScript() << Util::toVec<std::vector<uint8_t>>(txo.toBytes(false)));
                 return ret;
             };
 

--- a/src/Options.h
+++ b/src/Options.h
@@ -79,8 +79,9 @@ public:
     bool bitcoindUsesTls = false; ///< CLI: --bitcoind-tls. If true, we will connect to the remote bitcoind via SSL/TLS. See BitcoinD.cpp.
     QString rpcuser, rpcpassword;
     QString datadir; ///< The directory to store the database. It exists and has appropriate permissions (otherwise the app would have quit on startup).
-    /// If true, on db open/startup, we will perform some slow/paranoid db consistency checks
-    bool doSlowDbChecks = false;
+    /// If > 0, on db open/startup, we will perform some slow/paranoid db consistency checks
+    /// If 2, we do reverse-shunspent checks as well (even slower)
+    int doSlowDbChecks = 0;
 
     static constexpr double minPollTimeSecs = 0.5, maxPollTimeSecs = 30., defaultPollTimeSecs = 2.;
     /// bitcoin poll time interval. This value will always be in the range [minPollTimeSecs, maxPollTimeSecs] aka [0.5, 30]

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -355,6 +355,7 @@ private:
 
     void loadCheckHeadersInDB(); ///< may throw -- called from startup()
     void loadCheckUTXOsInDB(); ///< may throw -- called from startup()
+    void loadCheckShunspentInDB(); ///< may throw -- called from startup()
     void loadCheckTxNumsFileAndBlkInfo(); ///< may throw -- called from startup()
     void loadCheckEarliestUndo(); ///< may throw -- called from startup()
 
@@ -411,11 +412,11 @@ RocksDB: "scripthash_history"
 
 RocksDB: "utxoset"
   Purpose: serialize the UTXOSet structure as seen in the sources. loading this involves iterating over entire table.
-  Key: "prevouHashoutN (see struct TXO) (40 bytes)
+  Key: "prevoutHash+outN (see struct TXO) (34 or 35 bytes)
   Value:  8-byte amount , 32-byte hashX .. see struct TXOInfo.
 
 RocksDB: "scripthash_unspent"
-  Key: scripthash_raw_bytes + serialized CompactTXO (40 bytes)
+  Key: scripthash_raw_bytes + serialized CompactTXO (40 or 41 bytes)
   Value: 8-byte amount field (64-bit signed integer)
   Comments: It turns out scanning by prefix over a table is blazingly fast in rocksdb, so we can easily do listunspent
   using this scheme. I tried a read-modify-write approach (keying off just HashX) and it was painfully slow on synch.

--- a/src/TXO_Compact.h
+++ b/src/TXO_Compact.h
@@ -43,13 +43,14 @@ struct CompactTXO {
         /// tx index in the global tx table. First tx in blockchain is txNum 0, and so on (mapping of unique number to a txid hash, stored in db).
         /// Note this is really a 48 bit value covering the range [0, 281474976710655]
         std::uint64_t txNum : 48;
-        /// The the 'N' (output index) for the tx itself as per bitcoin tx format
-        std::uint16_t n;
-    } compact = { 0xffff'ffff'ffff, 0xffff };
+        /// The the 'N' (output index) for the tx itself as per bitcoin tx format. We support up to 24-bit IONums on-disk (16.7 million).
+        /// If the on-disk byte count is 8, we serialize/deserialize IONums as 16-bit. If it is 9, we serialize/deserialize as 24-bit.
+        std::uint32_t n : 24;
+    } compact = { 0xff'ff'ff'ff'ff'ff, 0xff'ff'ff };
     constexpr CompactTXO() noexcept = default;
     CompactTXO(TxNum txNum, IONum n) noexcept : compact{txNum, n} {}
     CompactTXO(const CompactTXO & o) noexcept : compact{o.compact} {}
-    CompactTXO & operator=(const CompactTXO & o) noexcept { std::memcpy(&compact, &o.compact, sizeof(compact)); return *this; }
+    CompactTXO & operator=(const CompactTXO & o) noexcept { compact.txNum = o.compact.txNum; compact.n = o.compact.n; return *this; }
     /// for most container types
     bool operator==(const CompactTXO &o) const noexcept { return compact.txNum == o.compact.txNum && compact.n == o.compact.n; }
     bool operator!=(const CompactTXO &o) const noexcept { return !(*this == o); }
@@ -60,44 +61,61 @@ struct CompactTXO {
     // convenience
     IONum N() const noexcept { return IONum(compact.n); }
     bool isValid() const { return *this != CompactTXO{}; }
-    static constexpr size_t serSize() noexcept { return 8; }
     QString toString() const { return isValid() ? QStringLiteral("%1:%2").arg(txNum()).arg(N()) : QStringLiteral("<compact_txo_invalid>"); }
-    /// Low-level serialization to a byte buffer in place.  Note that bufsz must be >= serSize().
-    /// Number of bytes written is returned, or 0 if bufsz to small.
-   size_t toBytesInPlace(std::byte *buf, size_t bufsz) const {
-        if (bufsz >= serSize()) {
+
+    /// Serialzied size is 8 bytes unless IONum is beyond 16-bit range, in which case it is 9 bytes. (If wide==true then always 9 bytes).
+    size_t serializedSize(bool wide) const noexcept { return wide || compact.n > IONum16Max ? maxSize() : minSize(); }
+    static constexpr size_t minSize() noexcept { return 8u; }
+    static constexpr size_t maxSize() noexcept { return 9u; }
+
+    /// Low-level serialization to a byte buffer in place.
+    ///
+    /// Note that bufsz must be >= serializedSize(wide) (which is 8 or 9 bytes, depending if IONum > 65535).
+    /// If wide == true, then the buffer must be 9 bytes (maxSize() bytes).
+    /// Number of bytes written is returned (8 or 9), or 0 if bufsz to small.
+   size_t toBytesInPlace(std::byte *buf, size_t bufsz, bool wide) const noexcept {
+        if (const auto sersize = serializedSize(wide); bufsz >= sersize) {
             txNumToCompactBytes(buf, compact.txNum);
-            buf[6] = std::byte((compact.n >> 0u) & 0xffu);
-            buf[7] = std::byte((compact.n >> 8u) & 0xffu);
-            return serSize();
+            buf[6] = std::byte(compact.n >> 0u & 0xffu);
+            buf[7] = std::byte(compact.n >> 8u & 0xffu);
+            if (sersize == maxSize())
+                buf[8] = std::byte(compact.n >> 16u & 0xffu);
+            return sersize;
         }
         return 0;
     }
-    QByteArray toBytes() const {
+    /// If wide == false, result is 8 or 9 bytes depending on how large N() is. If wide == true, then it's always 9 bytes.
+    QByteArray toBytes(bool wide) const {
         // the below is excessively wordy but it forces 8 byte little-endian style serialization
-        QByteArray ret(serSize(), Qt::Uninitialized);
-        toBytesInPlace(reinterpret_cast<std::byte *>(ret.data()), size_t(ret.size())); // this should never fail
+        QByteArray ret(serializedSize(wide), Qt::Uninitialized);
+        toBytesInPlace(reinterpret_cast<std::byte *>(ret.data()), size_t(ret.size()), wide); // this should never fail
         return ret;
     }
-    static CompactTXO fromBytes(const std::byte *buf, size_t bufsz) {
-        return fromBytes(QByteArray::fromRawData(reinterpret_cast<const char *>(buf), int(std::min(bufsz, serSize()))));
+    /// passed-in bufsz must be either minSize() (for 2-byte IONum <= 65535) or maxSize() (for 3-byte IONum)!
+    static CompactTXO fromBytesInPlaceExactSizeRequired(const std::byte *buf, size_t bufsz)  {
+        if (UNLIKELY(bufsz != minSize() && bufsz != maxSize()))
+            throw InternalError(QString("CompactTXO::fromBytesInPlaceExactSizeRequired was given an invalid size: %1").arg(bufsz));
+        return fromBytes(QByteArray::fromRawData(reinterpret_cast<const char *>(buf), int(bufsz)));
     }
-    /// passed-in QByteArray must be exactly serSize() bytes else nothing is converted
+    /// passed-in QByteArray must be exactly 8 or 9 bytes else nothing is converted
     static CompactTXO fromBytes(const QByteArray &b) {
         // the below is excessively wordy but it forces 8 byte little-endian style deserialization
         CompactTXO ret;
-        if (b.size() == serSize()) {
+        if (const auto sz = b.size(); sz == minSize() || sz == maxSize()) {
+            static_assert (maxSize() - minSize() == 1, "Assumption here is that minSize and maxSize differ in size by 1");
             const std::byte * cur = reinterpret_cast<const std::byte *>(b.constData());
             ret.compact.txNum = txNumFromCompactBytes(cur);
             ret.compact.n = IONum(cur[6]) | IONum(IONum(cur[7]) << 8u);
+            if (sz == maxSize())
+                ret.compact.n |= IONum(IONum(cur[8]) << 16u);
         }
         return ret;
     }
 
-    static constexpr size_t compactTxNumSize() { return 6; }
+    static constexpr size_t compactTxNumSize() noexcept { return 6; }
 
     /// Converts: TxNum (8 bytes) <- from a 6-byte buffer. Uses little-endian ordering.
-    static inline TxNum txNumFromCompactBytes(const std::byte bytes[6])
+    static inline TxNum txNumFromCompactBytes(const std::byte bytes[6]) noexcept
     {
         return    (TxNum(bytes[0]) <<  0u)
                 | (TxNum(bytes[1]) <<  8u)
@@ -107,14 +125,14 @@ struct CompactTXO {
                 | (TxNum(bytes[5]) << 40u);
     }
     /// Converts: TxNum (8 bytes) -> into a 6-byte buffer. Uses little-endian ordering.
-    static inline void txNumToCompactBytes(std::byte bytes[6], TxNum num)
+    static inline void txNumToCompactBytes(std::byte bytes[6], TxNum num) noexcept
     {
-        bytes[0] = std::byte((num >>  0u) & 0xffu);
-        bytes[1] = std::byte((num >>  8u) & 0xffu);
-        bytes[2] = std::byte((num >> 16u) & 0xffu);
-        bytes[3] = std::byte((num >> 24u) & 0xffu);
-        bytes[4] = std::byte((num >> 32u) & 0xffu);
-        bytes[5] = std::byte((num >> 40u) & 0xffu);
+        bytes[0] = std::byte(num >>  0u & 0xffu);
+        bytes[1] = std::byte(num >>  8u & 0xffu);
+        bytes[2] = std::byte(num >> 16u & 0xffu);
+        bytes[3] = std::byte(num >> 24u & 0xffu);
+        bytes[4] = std::byte(num >> 32u & 0xffu);
+        bytes[5] = std::byte(num >> 40u & 0xffu);
     }
 };
 #if defined(__GNUC__) || defined(__clang__)
@@ -124,16 +142,16 @@ struct CompactTXO {
 namespace std {
 /// specialization of std::hash to be able to add struct CompactTXO to any unordered_set or unordered_map
 template<> struct hash<CompactTXO> {
-    size_t operator()(const CompactTXO &ctxo) const noexcept {
-        const auto val1 = ctxo.txNum();
-        const auto val2 = ctxo.N();
+    size_t operator()(const CompactTXO &ctxo) const {
+        const std::uint64_t val1 = ctxo.txNum();
+        const std::uint32_t val2 = ctxo.N();
         // We must copy the txNum and the ionum to a temporary buffer and hash that.
         // Previously, we put these two items in a struct but it didn't have a unique
         // objected repr and that led to bugs.  See Fulcrum issue #47 on GitHub.
         std::array<std::byte, sizeof(val1) + sizeof(val2)> buf;
         std::memcpy(buf.data()               , reinterpret_cast<const char *>(&val1), sizeof(val1));
         std::memcpy(buf.data() + sizeof(val1), reinterpret_cast<const char *>(&val2), sizeof(val2));
-        // below hashes the above 10-byte buffer using CityHash64
+        // below hashes the above 12-byte buffer using CityHash64 (or MurMur3 if on 32-bit)
         return Util::hashForStd(buf);
     }
 };


### PR DESCRIPTION
Previous to this commit, we serialized TXO outN (IONum) as a 16-bit
number to the database, which theoretically is not enough. It's possible
for a bitcoin tx that is 1MB to have ~111k outputs (if they are all empty
scripts).  When I first wrote Fulcrum and designed the database format,
I did not realize such a thing is possible.

Luckily, no such tx's exist on any of the 6 chains we support between
BTC and BCH, however we should be able to handle such tx's should they
appear in the future.

This commit expands on the db format in a backward-compatible way, by
extending the TXO and CompactTXO formats to optionally serialize a
3-byte IONum if the value is >65535 (2-byte if <= 65535).

Internally now IONums are 32-bit numbers, but they only get serialized
as 16-bit numbers in the common case and 24-bit numbers in the rare case
of outN being >65535 (which is enough given current bitcoin consensus rules).

We were also forced to change the Undo format from v1 to v2 as a result
of this change. Older Fulcrum will not be able to use the undo table
written by newer Fulcrum.

This commit does introduce "breaking" changes to the DB format -- DBs
written by Fulcrum after this commit are not guaranteed to be 100%
readable by older Fulcrum.  However the new format is guaranteed to be
correct whereas the old format was not.

In practice it is hoped that server admins won't notice this "breaking"
change since I don't believe admins ever downgrade their Fulcrum
versions -- they tend to always move forward in terms of version.

And if a user were to read on old db with this newer Fulcrum it would be
fine.  The potential break only can happen if going backwards in terms
of Fulrum version after having run a version including this commit. (And
even then it likely won't get noticed unless there is a reorg right
after the db is loaded, in which case the undo info would not be readable
by older Fulcrum).