### PR TITLE
Add 3 new RPCs, plus add a new index: txhash -> txnum (for mapping tx's to their confirmed heights)

### DIFF
--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -301,6 +301,7 @@ SOURCES += \
     SrvMgr.cpp \
     Storage.cpp \
     SubsMgr.cpp \
+    SubStatus.cpp \
     ThreadPool.cpp \
     TXO.cpp \
     Util.cpp \

--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -279,6 +279,7 @@ SOURCES += \
     Common.cpp \
     Controller.cpp \
     Controller_SynchDSPsTask.cpp \
+    CoTask.cpp \
     DSProof.cpp \
     Json/Json.cpp \
     Json/Json_Parser.cpp \
@@ -324,6 +325,7 @@ HEADERS += \
     Controller.h \
     Controller_SynchDSPsTask.h \
     CostCache.h \
+    CoTask.h \
     DSProof.h \
     Json/Json.h \
     Logger.h \

--- a/contrib/rpm/fulcrum.spec
+++ b/contrib/rpm/fulcrum.spec
@@ -1,5 +1,5 @@
 Name:    {{{ git_name name="fulcrum" }}}
-Version: 1.4.1
+Version: 1.5.0
 Release: {{{ git_version }}}%{?dist}
 Summary: A fast & nimble SPV server for Bitcoin Cash
 

--- a/doc/fulcrum-example-config.conf
+++ b/doc/fulcrum-example-config.conf
@@ -637,7 +637,7 @@ rpcpassword = hunter1
 # db_max_open_files = 20
 
 
-# Max RocksDB Memory in MiB - 'db_mem' - DEFAULT: 384.0
+# Max RocksDB Memory in MiB - 'db_mem' - DEFAULT: 420.0
 #
 # Specifies roughly the maximum amount of memory to give to rocksdb. Larger
 # values offer better performance, at the expense of memory consumption. Note
@@ -650,7 +650,7 @@ rpcpassword = hunter1
 # works well on an SSD. If using an HDD for the datadir, you may want to set
 # this value higher than the default.
 #
-# db_mem = 384.0
+# db_mem = 420.0
 
 
 # RocksDB use "fsync" - 'db_use_fsync' - DEFAULT: false

--- a/doc/unix-man-page.md
+++ b/doc/unix-man-page.md
@@ -1,6 +1,6 @@
-% FULCRUM(1) Version 1.4.1 | Fulcrum Manual
+% FULCRUM(1) Version 1.5.0 | Fulcrum Manual
 % Fulcrum is written by Calin Culianu (cculianu)
-% February 11, 2021
+% March 02, 2021
 
 # NAME
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -477,6 +477,12 @@ void App::parseArgs()
         QString("num"),
     },
     {
+        "no-txhash-index",
+        QString("Disable the txhash index. Some RPC methods will be unavailable to clients as a result, so this is not"
+                " recommended. This option is provided for admins wishing to opt-out of the db upgrade required to"
+                " enable the txhash index.\n")
+    },
+    {
        "dump-sh",
        QString("*** This is an advanced debugging option ***   Dump script hashes. If specified, after the database"
                " is loaded, all of the script hashes in the database will be written to outputfile as a JSON array.\n"),
@@ -1218,6 +1224,12 @@ void App::parseArgs()
                           .arg(options->txHashCacheBytesMin/1e6).arg(options->txHashCacheBytesMax/1e6));
         options->txHashCacheBytes = val;
         Util::AsyncOnObject(this, [val=val/1e6]{ DebugM("config: txhash_cache = ", val); });
+    }
+
+    // CLI: --no-txhash-index
+    if (parser.isSet("no-txhash-index")) {
+        options->noTxHashIndex = true;
+        Util::AsyncOnObject(this, []{ DebugM("no-txhash-index: true"); });
     }
 
     // parse --dump-*

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -477,12 +477,6 @@ void App::parseArgs()
         QString("num"),
     },
     {
-        "no-txhash-index",
-        QString("Disable the txhash index. Some RPC methods will be unavailable to clients as a result, so this is not"
-                " recommended. This option is provided for admins wishing to opt-out of the db upgrade required to"
-                " enable the txhash index.\n")
-    },
-    {
        "dump-sh",
        QString("*** This is an advanced debugging option ***   Dump script hashes. If specified, after the database"
                " is loaded, all of the script hashes in the database will be written to outputfile as a JSON array.\n"),
@@ -1224,12 +1218,6 @@ void App::parseArgs()
                           .arg(options->txHashCacheBytesMin/1e6).arg(options->txHashCacheBytesMax/1e6));
         options->txHashCacheBytes = val;
         Util::AsyncOnObject(this, [val=val/1e6]{ DebugM("config: txhash_cache = ", val); });
-    }
-
-    // CLI: --no-txhash-index
-    if (parser.isSet("no-txhash-index")) {
-        options->noTxHashIndex = true;
-        Util::AsyncOnObject(this, []{ DebugM("no-txhash-index: true"); });
     }
 
     // parse --dump-*

--- a/src/App.h
+++ b/src/App.h
@@ -56,18 +56,23 @@ public:
     std::shared_ptr<Options> options;
 
     /// app-global ids used for JSON-RPC 'id', as well as app-level objects we wish to track by id rather than pointer
-    inline quint64 newId() { return ++globalId; }
+    quint64 newId() { return ++globalId; }
 
     /// This is only ever true if the aboutToQuit signal has fired (as a result of this->exit() or this->quit())
-    inline bool isQuitting() const { return quitting; }
+    bool isQuitting() const { return quitting; }
 
-    inline ThreadPool *threadPool() const { return tpool.get(); }
+    /// This is thread-safe. Returns the number of SIGINT, etc signals that were caught. If this is ever above
+    /// 0, the app is about to exit. This is provided in case long-running tasks may wish to check this value
+    /// periodically.
+    int signalsCaught() const { return int(sigCtr); }
+
+    ThreadPool *threadPool() const { return tpool.get(); }
 
     /// Performance optimization to avoid dynamic_cast<App *>(qApp) in ::app() below.
-    static inline App * globalInstance() { return _globalInstance; }
+    static App * globalInstance() { return _globalInstance; }
 
     /// Convenience to obtain our singleton ThreadPool instance that goes with this singleton App instance.
-    static inline ThreadPool *globalThreadPool() { return _globalInstance ? _globalInstance->threadPool() : nullptr; }
+    static ThreadPool *globalThreadPool() { return _globalInstance ? _globalInstance->threadPool() : nullptr; }
 
     // -- Test & Bench support (requires -DENABLE_TESTS) --
     using RegisteredTest = struct{};

--- a/src/ByteView.h
+++ b/src/ByteView.h
@@ -88,6 +88,9 @@ public:
         return deepCopy ? QByteArray{charData(), int(size())}
                         : QByteArray::fromRawData(charData(), int(size()));
     }
+
+    /// Convenience: reimplements super class, but in this case to return a ByteView
+    ByteView substr(size_type pos = 0, size_type count = npos) const { return Base::substr(pos, count); }
 };
 
 /// String literal -> ByteView e.g.: "foo"_bv or "\x01\xff\x07\xab"_bv

--- a/src/CoTask.cpp
+++ b/src/CoTask.cpp
@@ -1,0 +1,77 @@
+//
+// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// Copyright (C) 2019-2021  Calin A. Culianu <calin.culianu@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program (see LICENSE.txt).  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+#include "CoTask.h"
+#include "Util.h"
+
+#include <QThread>
+
+CoTask::CoTask(const QString &name)
+{
+    thr = std::thread([this, name] {
+        if (QThread *qthr; !name.isEmpty() && (qthr = QThread::currentThread()))
+            qthr->setObjectName(name);
+        thrFunc();
+    });
+}
+
+CoTask::~CoTask()
+{
+    if (thr.joinable()) {
+        DebugM(__func__, ": joining thread");
+        {
+            std::unique_lock g(mut);
+            pleaseStop = true;
+            cond.notify_all();
+        }
+        thr.join();
+    }
+}
+
+void CoTask::thrFunc()
+{
+    DebugM("CoTask thread started");
+    const Tic t0;
+    unsigned ctr = 0;
+    Defer d([&t0, &ctr] {
+        DebugM("CoTask thread exited, ran ", ctr, Util::Pluralize(" job", ctr), ", elapsed total: ",
+               t0.secsStr(1), " secs");
+    });
+    std::unique_lock lock(mut);
+    for (;;) {
+        if (pleaseStop)
+            return;
+        if (work) {
+            // we do work with the lock held -- the design is 1 job can be submitted at a time
+            // and if caller attempts to submit a second one, they will block
+            ++ctr;
+            std::function<void()> mywork;
+            mywork.swap(work);
+            std::promise<void> myprom;
+            myprom.swap(prom);
+            try {
+                mywork();
+                myprom.set_value();
+            } catch (...) {
+                myprom.set_exception(std::current_exception());
+            }
+        } else {
+            cond.wait(lock);
+        }
+    }
+}

--- a/src/CoTask.h
+++ b/src/CoTask.h
@@ -1,0 +1,96 @@
+//
+// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// Copyright (C) 2019-2021  Calin A. Culianu <calin.culianu@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program (see LICENSE.txt).  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+#pragma once
+
+#include <QString>
+#include <QtGlobal>
+
+#include <condition_variable>
+#include <exception>
+#include <functional>
+#include <future>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+
+/// A lightweight "Coroutine Task" (not to be confused with C++20 coroutines). This is a thread that waits
+/// for work to be submitted to it via a lambda.
+class CoTask
+{
+    Q_DISABLE_COPY_MOVE(CoTask);
+public:
+    CoTask(const QString &name = {});
+    ~CoTask();
+
+    // A wrapper for future that automatically waits for the wrapped future on destruction.
+    struct Future {
+        std::future<void> future;
+        Future() = default;
+        Future(Future &&o) : future(std::move(o.future)) {}
+        Future(std::future<void> && f) : future(std::move(f)) {}
+        Future &operator=(Future &&o) {
+            if (future.valid()) throw std::domain_error("Attempt to move a future onto an already-active future");
+            future = std::move(o.future);
+            return *this;
+        }
+        /// Note: This will throw if the future has an exception in it
+        ~Future() noexcept(false) try {
+            if (future.valid())
+                future.get(); // auto-wait for the value, will throw if the worker threw
+        } catch (...) {
+            if (std::uncaught_exceptions()) {
+                qCritical("CoTask::Future::~Future caught an exception from its future object, but the stack is in"
+                          " the process of unwinding from another exception, ignoring!");
+                return; // suppress rethrow in this case: if a d'tor returns in a catch clause, no rethrow happens
+            }
+            throw; // re-throw just to be explicit. if we didn't do this, d'tor would rethrow anyway for us (if no return statement)
+        }
+    };
+
+    /// Submit a lambda to be worked-on by the worker thread associated with this instance. If work was already
+    /// active when this is called, this will block. Not designed to submit more than 1 piece of work
+    /// at a time.  Intended operation: Submit work, go do something else, then wait for the future, then submit again
+    /// later after it's done, etc.
+    template <typename Function, typename = std::enable_if_t<std::is_invocable_r_v<void, Function>>>
+    [[nodiscard]] Future submitWork(Function && func) {
+        std::unique_lock g(mut);
+        if (work) throw std::domain_error("Attempt to submit work while work is already pending");
+        work = std::forward<Function>(func);
+        return submitWorkInner();
+    }
+
+private:
+    std::thread thr;
+    std::mutex mut;
+    std::condition_variable cond;
+    std::promise<void> prom;
+    std::atomic_bool pleaseStop{false};
+    std::function<void()> work;
+
+    void thrFunc();
+    /// requires mutex be held when called -- it's here to make the above public section less cluttered
+    [[nodiscard]] Future submitWorkInner() {
+        prom = std::promise<void>();
+        Future ret{ prom.get_future() };
+        cond.notify_one();
+        return ret;
+    }
+};
+

--- a/src/Common.h
+++ b/src/Common.h
@@ -39,7 +39,7 @@ struct InternalError : Exception { using Exception::Exception; ~InternalError() 
 struct BadArgs : Exception { using Exception::Exception; ~BadArgs() override; };
 
 #define APPNAME "Fulcrum"
-#define VERSION "1.4.1"
+#define VERSION "1.5.0"
 #ifdef QT_DEBUG
 inline constexpr bool isReleaseBuild() { return false; }
 #else

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -1720,7 +1720,7 @@ auto Controller::stats() const -> Stats
     st["Misc"] = misc;
     st["SubsMgr"] = storage->subs()->statsSafe(kDefaultTimeout/2);
     st["SubsMgr (DSPs)"] = storage->dspSubs()->statsSafe(kDefaultTimeout/4);
-    st["SubsMgr (Transactions)"] = storage->txSubs()->statsSafe(kDefaultTimeout/4);
+    st["SubsMgr (Txs)"] = storage->txSubs()->statsSafe(kDefaultTimeout/4);
     // Config (Options) map
     st["Config"] = options->toMap();
     { // Process memory usage
@@ -1795,7 +1795,7 @@ auto Controller::debug(const StatsParams &p) const -> Stats // from StatsMixin
     }
     if (p.contains("txsubs")) {
         const auto timeLeft = kDefaultTimeout - (Util::getTime() - t0/1000000) - 50;
-        ret["subscriptions (Transactions)"] = storage->txSubs()->debugSafe(p, std::max(5, int(timeLeft)));
+        ret["subscriptions (Txs)"] = storage->txSubs()->debugSafe(p, std::max(5, int(timeLeft)));
     }
     const auto elapsed = Util::getTimeNS() - t0;
     ret["elapsed"] = QString::number(elapsed/1e6, 'f', 6) + " msec";

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -1719,7 +1719,8 @@ auto Controller::stats() const -> Stats
     misc["Job Queue (Thread Pool)"] = ::AppThreadPool()->stats();
     st["Misc"] = misc;
     st["SubsMgr"] = storage->subs()->statsSafe(kDefaultTimeout/2);
-    st["SubsMgr (DSPs)"] = storage->dspSubs()->statsSafe(kDefaultTimeout/2);
+    st["SubsMgr (DSPs)"] = storage->dspSubs()->statsSafe(kDefaultTimeout/4);
+    st["SubsMgr (Transactions)"] = storage->txSubs()->statsSafe(kDefaultTimeout/4);
     // Config (Options) map
     st["Config"] = options->toMap();
     { // Process memory usage
@@ -1791,6 +1792,10 @@ auto Controller::debug(const StatsParams &p) const -> Stats // from StatsMixin
     if (p.contains("dspsubs")) {
         const auto timeLeft = kDefaultTimeout - (Util::getTime() - t0/1000000) - 50;
         ret["subscriptions (DSProof)"] = storage->dspSubs()->debugSafe(p, std::max(5, int(timeLeft)));
+    }
+    if (p.contains("txsubs")) {
+        const auto timeLeft = kDefaultTimeout - (Util::getTime() - t0/1000000) - 50;
+        ret["subscriptions (Transactions)"] = storage->txSubs()->debugSafe(p, std::max(5, int(timeLeft)));
     }
     const auto elapsed = Util::getTimeNS() - t0;
     ret["elapsed"] = QString::number(elapsed/1e6, 'f', 6) + " msec";

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -612,7 +612,10 @@ struct SynchMempoolTask : public CtlTask
 {
     SynchMempoolTask(Controller *ctl_, std::shared_ptr<Storage> storage, const std::atomic_bool & notifyFlag)
         : CtlTask(ctl_, "SynchMempool"), storage(storage), notifyFlag(notifyFlag), isBTC(ctl_->isCoinBTC())
-        { scriptHashesAffected.reserve(SubsMgr::kRecommendedPendingNotificationsReserveSize); }
+    {
+        scriptHashesAffected.reserve(SubsMgr::kRecommendedPendingNotificationsReserveSize);
+        txidsAffected.reserve(SubsMgr::kRecommendedPendingNotificationsReserveSize);
+    }
     ~SynchMempoolTask() override;
     void process() override;
 
@@ -633,6 +636,8 @@ struct SynchMempoolTask : public CtlTask
     std::unordered_set<HashX, HashHasher> scriptHashesAffected;
     /// The txids in the adds or drops that also have dsproofs associated with them (cumulative across retries, like scriptHashesAffected)
     Mempool::TxHashSet dspTxsAffected;
+    /// The txids either added or dropped -- for the txSubsMgr
+    std::unordered_set<TxHash, HashHasher> txidsAffected;
 
     void clear() {
         isdlingtxs = false;
@@ -643,6 +648,7 @@ struct SynchMempoolTask : public CtlTask
         // all the droppedTx scripthashes for each retry, so we never clear the set.
         // Note 2: we also never clear the redoCt since that counter needs to maintain state to abort too many redos.
         // Note 3: we also never clear dspTxsAffected
+        // Note 4: we never clear txidsAffected
     }
 
     /// Called when getrawtransaction errors out or when we dropTxs() and the result is too many txs so we must
@@ -669,6 +675,10 @@ SynchMempoolTask::~SynchMempoolTask() {
         if (!dspTxsAffected.empty()) {
             DebugM(objectName(), ": dspTxsAffected: ", dspTxsAffected.size());
             storage->dspSubs()->enqueueNotifications(std::move(dspTxsAffected));
+        }
+        if (!txidsAffected.empty()) {
+            //DebugM(objectName(), ": txidsAffected: ", txidsAffected.size());
+            storage->txSubs()->enqueueNotifications(std::move(txidsAffected));
         }
     }
 
@@ -901,6 +911,7 @@ void SynchMempoolTask::doDLNextTx()
             return;
         }
 
+        txidsAffected.insert(tx->hash);
         txsWaitingForResponse.erase(tx->hash);
         updateLastProgress();
         AGAIN();
@@ -980,6 +991,10 @@ void SynchMempoolTask::doGetRawMempool()
                 auto [mempool, lock] = storage->mutableMempool();
                 res = mempool.dropTxs(affected, droppedTxs, TRACE);
             } // release lock
+
+            // update this set too for txSubsMgr
+            txidsAffected.insert(droppedTxs.begin(), droppedTxs.end());
+
             // do bookkeeping, maybe print debug log
             {
                 droppedCt = res.oldSize - res.newSize;

--- a/src/Options.h
+++ b/src/Options.h
@@ -202,7 +202,7 @@ public:
         unsigned keepLogFileNum = defaultKeepLogFileNum;
         static constexpr bool isKeepLogFileNumInBounds(int64_t k) { return k >= int64_t(minKeepLogFileNum) && k <= int64_t(maxKeepLogFileNum); }
 
-        static constexpr size_t defaultMaxMem = 384 * 1024 * 1024, maxMemMin = 50 * 1024 * 1024, maxMemMax = std::numeric_limits<size_t>::max();
+        static constexpr size_t defaultMaxMem = 420 * 1024 * 1024, maxMemMin = 50 * 1024 * 1024, maxMemMax = std::numeric_limits<size_t>::max();
         size_t maxMem = defaultMaxMem;
         static constexpr bool isMaxMemInBounds(size_t mem) { return mem >= maxMemMin && mem <= maxMemMax; }
 

--- a/src/Options.h
+++ b/src/Options.h
@@ -261,9 +261,6 @@ public:
                               txHashCacheBytesMin = 20'000'000; ///< 20 MB minimum
     static constexpr bool isTxHashCacheBytesInRange(unsigned n) { return n >= txHashCacheBytesMin && n <= txHashCacheBytesMax; }
     unsigned txHashCacheBytes = defaultTxHashCacheBytes;
-
-    // CLI: --no-txhash-index (default: false)
-    bool noTxHashIndex = false;
 };
 
 /// A class encapsulating a simple read-only config file format.  The format is similar to the bitcoin.conf format

--- a/src/Options.h
+++ b/src/Options.h
@@ -261,6 +261,9 @@ public:
                               txHashCacheBytesMin = 20'000'000; ///< 20 MB minimum
     static constexpr bool isTxHashCacheBytesInRange(unsigned n) { return n >= txHashCacheBytesMin && n <= txHashCacheBytesMax; }
     unsigned txHashCacheBytes = defaultTxHashCacheBytes;
+
+    // CLI: --no-txhash-index (default: false)
+    bool noTxHashIndex = false;
 };
 
 /// A class encapsulating a simple read-only config file format.  The format is similar to the bitcoin.conf format

--- a/src/RecordFile.h
+++ b/src/RecordFile.h
@@ -68,7 +68,12 @@ public:
     /// circumstances, the returned array will be of the same size as the recNums array, with corresponding indices
     /// containing the data obtained per recNum.  On error the returned array will be shorter than anticipated
     /// and *errStr (if specified) will be set appropriately.  Note that the recNums array is not "de-duplicated".
-    std::vector<QByteArray> readRandomRecords(const std::vector<uint64_t> & recNums, QString *errStr = nullptr) const;
+    ///
+    /// New: If `continueOnError` is true, the returned vector will always be sized exactly the same as recNums.
+    /// Any errors encountered will simply have empty QByteArrays inserted into the resulting vector. *errStr
+    /// will be the last error encountered if there are errors.
+    std::vector<QByteArray> readRandomRecords(const std::vector<uint64_t> & recNums, QString *errStr = nullptr,
+                                              bool continueOnError = false) const;
 
     /// Thread-safe, but it does take an exclusive lock.  Appends data to the file. The new record number is returned.
     /// Note that an error leads to an optional with no value being returned.  Data *must* be recordSize() bytes.

--- a/src/ServerMisc.cpp
+++ b/src/ServerMisc.cpp
@@ -4,7 +4,7 @@
 namespace ServerMisc
 {
     const Version MinProtocolVersion(1,4,0);
-    const Version MaxProtocolVersion(1,4,4);
+    const Version MaxProtocolVersion(1,4,5);
     const QString AppVersion(VERSION);
     const QString AppSubVersion = QString("%1 %2").arg(APPNAME).arg(VERSION);
 }

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -376,6 +376,8 @@ private:
     void rpc_blockchain_transaction_get_height(Client *, const RPC::Message &); // fully implemented
     void rpc_blockchain_transaction_get_merkle(Client *, const RPC::Message &); // fully implemented
     void rpc_blockchain_transaction_id_from_pos(Client *, const RPC::Message &); // fully implemented
+    void rpc_blockchain_transaction_subscribe(Client *, const RPC::Message &); // fully implemented
+    void rpc_blockchain_transaction_unsubscribe(Client *, const RPC::Message &); // fully implemented
     // transaction.dsproof
     void rpc_blockchain_transaction_dsproof_get(Client *, const RPC::Message &); // fully implemented
     void rpc_blockchain_transaction_dsproof_list(Client *, const RPC::Message &); // fully implemented

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -373,6 +373,7 @@ private:
     // transaction
     void rpc_blockchain_transaction_broadcast(Client *, const RPC::Message &); // fully implemented
     void rpc_blockchain_transaction_get(Client *, const RPC::Message &); // fully implemented
+    void rpc_blockchain_transaction_get_height(Client *, const RPC::Message &); // fully implemented
     void rpc_blockchain_transaction_get_merkle(Client *, const RPC::Message &); // fully implemented
     void rpc_blockchain_transaction_id_from_pos(Client *, const RPC::Message &); // fully implemented
     // transaction.dsproof

--- a/src/SrvMgr.cpp
+++ b/src/SrvMgr.cpp
@@ -482,6 +482,7 @@ void SrvMgr::globalSubsLimitReached()
                 // we do it with a delay to give the kick code time to run.
                 emit storage->subs()->requestRemoveZombiesSoon(when);
                 emit storage->dspSubs()->requestRemoveZombiesSoon(when);
+                emit storage->txSubs()->requestRemoveZombiesSoon(when);
             }
         };
 

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -3240,7 +3240,7 @@ namespace {
 
                 // save scripthash history for this hashX, by appending to existing history. Note that this uses
                 // the 'ConcatOperator' class we defined in this file, which requires rocksdb be compiled with RTTI.
-                if (auto st = batch.Merge(ToSlice(key), ToSlice(val.bytes())); !st.ok())
+                if (auto st = batch.Merge(ToSlice(key), ToSlice(val.byteView())); !st.ok())
                     throw DatabaseError(QString("batch merge fail for %1").arg(QString(rec.toHex())));
                 ++i;
             }
@@ -3352,7 +3352,7 @@ namespace {
         iter->Reset();
         iter.reset();
 
-        Log() << "Read: " << verified << " total, merge operations: " << mergeOpCt(opts) << ", elapsed: " << t0.secsStr(2) << " sec";
+        Log() << "Verified: " << verified << " total, merge operations: " << mergeOpCt(opts) << ", elapsed: " << t0.secsStr(2) << " sec";
         Log() << "Closing db ...";
         rocksdb::Status status;
         rocksdb::FlushOptions fopts;

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -65,9 +65,6 @@ struct UndoInfoMissing : public Exception { using Exception::Exception; ~UndoInf
 /// Thrown by internally by getHistory and listUnspent if the history is too large (larger than max_history from config).
 struct HistoryTooLarge : public Exception { using Exception::Exception; ~HistoryTooLarge() override; };
 
-/// Thrown by methods such as getTxHeights() if e.g. the txhash index is missing.
-struct IndexDisabled : public Exception { using Exception::Exception; ~IndexDisabled() override; };
-
 class ScriptHashSubsMgr;
 class DSProofSubsMgr;
 class TransactionSubsMgr;
@@ -292,19 +289,15 @@ public:
     Mempool::FeeHistogramVec mempoolHistogram() const;
 
     // -- Tx Hash index based methods
-
-    /// Thread-safe. Test whether the txhash index is enabled. Default true. Comes from CLI options: --no-txhash-index.
-    bool hasTxHashIndex() const { return !options->noTxHashIndex; }
-
     using TxHeightsResult = std::vector<std::optional<BlockHeight>>;
     /// Thread-safe. Does take mempool, blkInfo, and blocksLock locks in shared mode. Returns an array whose length is
     /// equal to txHashes.size(), and for each element: if the optional is valid, then BlockHeight=0 means mempool,
     /// and >0 means a confirmed height. If a particular TxHash was not found in the mempool or blockchain, that element
     /// will have a std::nullopt.
     ///
-    /// Note that if the tx hash index is not enabled, this will throw IndexDisabled.  May throw DatabaseError (unlikely)
-    /// or some other Exception subclass.  Note that txHashes should contain 0 or more 32-byte hashes in big-endian
-    /// (JSON) memory order, otherwise this may throw if the hashes are of the wrong length.
+    /// May throw DatabaseError (unlikely) or some other Exception subclass.  Note that txHashes should contain 0 or
+    /// more 32-byte hashes in big-endian (JSON) memory order, otherwise this may throw if the hashes are of the wrong
+    /// length.
     TxHeightsResult getTxHeights(const std::vector<TxHash> &txHashes) const;
     /// Convenience function. Calls above.
     std::optional<BlockHeight> getTxHeight(const TxHash &) const;

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -299,7 +299,7 @@ public:
     /// more 32-byte hashes in big-endian (JSON) memory order, otherwise this may throw if the hashes are of the wrong
     /// length.
     TxHeightsResult getTxHeights(const std::vector<TxHash> &txHashes) const;
-    /// Convenience function. Calls above.
+    /// Convenience function. Same as above but optimized to query a single txhash.
     std::optional<BlockHeight> getTxHeight(const TxHash &) const;
 
     // --- DUMP methods --- (used for debugging, largely)

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -65,6 +65,9 @@ struct UndoInfoMissing : public Exception { using Exception::Exception; ~UndoInf
 /// Thrown by internally by getHistory and listUnspent if the history is too large (larger than max_history from config).
 struct HistoryTooLarge : public Exception { using Exception::Exception; ~HistoryTooLarge() override; };
 
+/// Thrown by methods such as getTxHeights() if e.g. the txhash index is missing.
+struct IndexDisabled : public Exception { using Exception::Exception; ~IndexDisabled() override; };
+
 class ScriptHashSubsMgr;
 class DSProofSubsMgr;
 
@@ -285,8 +288,23 @@ public:
     /// Takes a shared lock and returns the cached mempool histogram (calculated periodically in refreshMempoolHistogram above)
     Mempool::FeeHistogramVec mempoolHistogram() const;
 
+    // -- Tx Hash index based methods
+
     /// Thread-safe. Test whether the txhash index is enabled. Default true. Comes from CLI options: --no-txhash-index.
     bool hashTxHashIndex() const { return !options->noTxHashIndex; }
+
+    using TxHeightsResult = std::vector<std::optional<BlockHeight>>;
+    /// Thread-safe. Does take mempool, blkInfo, and blocksLock locks in shared mode. Returns an array whose length is
+    /// equal to txHashes.size(), and for each element: if the optional is valid, then BlockHeight=0 means mempool,
+    /// and >0 means a confirmed height. If a particular TxHash was not found in the mempool or blockchain, that element
+    /// will have a std::nullopt.
+    ///
+    /// Note that if the tx hash index is not enabled, this will throw IndexDisabled.  May throw DatabaseError (unlikely)
+    /// or some other Exception subclass.  Note that txHashes should contain 0 or more 32-byte hashes in big-endian
+    /// (JSON) memory order, otherwise this may throw if the hashes are of the wrong length.
+    TxHeightsResult getTxHeights(const std::vector<TxHash> &txHashes) const;
+    /// Convenience function. Calls above.
+    std::optional<BlockHeight> getTxHeight(const TxHash &) const;
 
     // --- DUMP methods --- (used for debugging, largely)
 
@@ -381,6 +399,9 @@ private:
 
     /// Called from cleanup. Does some flushing and gently closes all open DBs.
     void gentlyCloseAllDBs();
+
+    // Called by heightForTxNum which calls this with the blockInfo lock held
+    std::optional<unsigned> heightForTxNum_nolock(TxNum) const;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Storage::SaveSpec)

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -386,8 +386,6 @@ private:
     void loadCheckTxHash2TxNumMgr(); ///< may throw -- called from startup()
     void loadCheckEarliestUndo(); ///< may throw -- called from startup()
 
-    void rebuildTxHash2TxNumTable(); ///< called from startup(), does a full rebuild of the txhash2num table from the TxNumsFile.
-
     std::optional<Header> headerForHeight_nolock(BlockHeight height, QString *errMsg = nullptr) const;
     std::vector<Header> headersFromHeight_nolock_nocheck(BlockHeight height, unsigned count, QString *errMsg = nullptr) const;
 

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -365,6 +365,7 @@ private:
     void loadCheckUTXOsInDB(); ///< may throw -- called from startup()
     void loadCheckShunspentInDB(); ///< may throw -- called from startup()
     void loadCheckTxNumsFileAndBlkInfo(); ///< may throw -- called from startup()
+    void loadCheckTxHash2TxNumMgr(); ///< may throw -- called from startup()
     void loadCheckEarliestUndo(); ///< may throw -- called from startup()
 
     std::optional<Header> headerForHeight_nolock(BlockHeight height, QString *errMsg = nullptr) const;

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -70,6 +70,7 @@ struct IndexDisabled : public Exception { using Exception::Exception; ~IndexDisa
 
 class ScriptHashSubsMgr;
 class DSProofSubsMgr;
+class TransactionSubsMgr;
 
 /// Manages the db and all storage-related facilities.  Most of its public methods are fully reentrant and thread-safe.
 class Storage final : public Mgr, public ThreadObjectMixin
@@ -280,6 +281,8 @@ public:
     ScriptHashSubsMgr * subs() const { return subsmgr.get(); }
     /// Identical to above, but points to the DSProofSubsMgr for this instance.
     DSProofSubsMgr * dspSubs() const { return dspsubsmgr.get(); }
+    /// Identical to above, but points to the TransactionSubsMgr for this instance.
+    TransactionSubsMgr * txSubs() const { return txsubsmgr.get(); }
 
     /// called from a timer periodically from Controller (see Controller.cpp)
     /// -- takes locks, updates compact fee histogram for the mempool
@@ -291,7 +294,7 @@ public:
     // -- Tx Hash index based methods
 
     /// Thread-safe. Test whether the txhash index is enabled. Default true. Comes from CLI options: --no-txhash-index.
-    bool hashTxHashIndex() const { return !options->noTxHashIndex; }
+    bool hasTxHashIndex() const { return !options->noTxHashIndex; }
 
     using TxHeightsResult = std::vector<std::optional<BlockHeight>>;
     /// Thread-safe. Does take mempool, blkInfo, and blocksLock locks in shared mode. Returns an array whose length is
@@ -375,6 +378,7 @@ private:
     const std::shared_ptr<const Options> options;
     const std::unique_ptr<ScriptHashSubsMgr> subsmgr;
     const std::unique_ptr<DSProofSubsMgr> dspsubsmgr;
+    const std::unique_ptr<TransactionSubsMgr> txsubsmgr;
 
     struct Pvt;
     const std::unique_ptr<Pvt> p;

--- a/src/SubStatus.cpp
+++ b/src/SubStatus.cpp
@@ -1,0 +1,34 @@
+//
+// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// Copyright (C) 2019-2021  Calin A. Culianu <calin.culianu@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program (see LICENSE.txt).  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+#include "SubStatus.h"
+#include "Util.h"
+
+QVariant SubStatus::toVariant() const
+{
+    QVariant ret; // if empty we simply notify as 'null'
+    if (has_value()) {
+        if (auto *ba = byteArray(); ba && !ba->isEmpty())
+            ret = Util::ToHexFast(*ba);
+        else if (auto *dsp = dsproof(); dsp && !dsp->isEmpty())
+            ret = dsp->toVarMap();
+        else if (auto *bh = blockHeight(); bh && *bh)
+            ret = **bh; // ptr -> optional -> value
+    }
+    return ret;
+}

--- a/src/SubStatus.h
+++ b/src/SubStatus.h
@@ -22,6 +22,7 @@
 
 #include <QByteArray>
 #include <QMetaType>
+#include <QVariant>
 
 #include <cstdint>
 #include <memory>
@@ -176,6 +177,11 @@ public:
 
     const std::optional<BlockHeight> * blockHeight() const noexcept { return t == BH ? &bh : nullptr; }
     std::optional<BlockHeight> * blockHeight() noexcept { return t == BH ? &bh : nullptr; }
+
+    /// Render this for JSON RPC (as a status result for notifications).  If !has_value() then it will be null,
+    /// otherwise if it has a valid value it will be rendered as a string, or a dsproof object, or a number.
+    /// Note that even if has_value(), this may still be a QVariant() (null).
+    QVariant toVariant() const;
 };
 
 /// Specialization of std::hash so we can use SubStatus with std::unordered_map, std::unordered_set, etc

--- a/src/SubStatus.h
+++ b/src/SubStatus.h
@@ -25,12 +25,13 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <type_traits>
 #include <utility> // for move
 
 /// This class is sort of like a variant/optional combination. It can store either "No Value" (!.has_value()) or
-/// either a DSProof or a QByteArray. It is optimized for minimal memory usage in the common case -- taking up
-/// as much memory as a std::optional<QByteArray>.
+/// either a: QByteArray, DSProof or a std::optional<BlockHeight>. It is optimized for minimal memory usage in the
+/// common case -- taking up as much memory as a std::optional<QByteArray> (16 bytes on 64-bit).
 ///
 /// It is intended to be used with the SubsMgr and its subclasses.
 ///
@@ -40,19 +41,24 @@
 /// - DSProofSubsMgr::getFullStatus() always returns one of these objects with the DSProof as the active value,
 ///   that is, dsproof() will always be a valid pointer.
 ///
+/// - TransactionSubsMgr::getFullStatus() always returns one of these objects with the std::optional<BlockHeight> as
+///   the active value, that is, blockHeight() will always be a valid pointer (even if it itself !has_value()).
+///
 class SubStatus {
     union {
         QByteArray qba;
         std::unique_ptr<DSProof> dsp; // we use unique_ptr here to save memory in the common case where most of these instances are QByteArray
+        std::optional<BlockHeight> bh; // !has_value indicates unknown txhash, otherwise 0 = mempool, >0 = confirmed height
         void *dummy = nullptr;
     };
-    enum T : uint8_t { NoValue, QBA, DSP };
+    enum T : uint8_t { NoValue, QBA, DSP, BH };
     T t = NoValue;
     void destruct() {
         switch (t) {
         case NoValue: return;
         case QBA: qba.~QByteArray(); break;
         case DSP: dsp.~unique_ptr(); break;
+        case BH : bh.~optional(); break;
         }
         dummy = nullptr;
         t = NoValue;
@@ -66,6 +72,9 @@ class SubStatus {
             break;
         case DSP:
             new (&dsp) std::unique_ptr<DSProof>(new DSProof);
+            break;
+        case BH:
+            new (&bh) std::optional<BlockHeight>;
             break;
         }
         t = tt;
@@ -81,24 +90,28 @@ class SubStatus {
                 t = DSP;
                 // fall thru to below code to transfer pointer
             } else {
-                // normal case: QBA or NoValue
+                // normal case: QBA, BH, or NoValue
                 construct(o.t);
             }
         }
         // at this point t == o.t
-        if (t == QBA)
-            qba = std::move(o.qba);
-        else if (t == DSP)
-            dsp = std::move(o.dsp); // cheap pointer transfer
+        switch (t) {
+        case NoValue: break; // nothing to do
+        case QBA: qba = std::move(o.qba); break;
+        case DSP: dsp = std::move(o.dsp); break; // cheap pointer transfer
+        case BH: bh = std::move(o.bh); break;
+        }
     }
     void copy(const SubStatus &o) {
         if (this == &o) return;
         if (t != o.t)
             construct(o.t);
-        if (t == QBA)
-            qba = o.qba;
-        else if (t == DSP)
-            *dsp = *o.dsp;
+        switch (t) {
+        case NoValue: break;
+        case QBA: qba = o.qba; break;
+        case DSP: *dsp = *o.dsp; break;
+        case BH: bh = o.bh; break;
+        }
     }
 public:
     constexpr SubStatus() noexcept {}
@@ -108,6 +121,7 @@ public:
     SubStatus(QByteArray &&oq) noexcept : qba(std::move(oq)), t{QBA} {}
     SubStatus(const DSProof &od) : dsp(new DSProof(od)), t{DSP} {}
     SubStatus(DSProof &&od) : dsp(new DSProof(std::move(od))), t{DSP} {}
+    SubStatus(const std::optional<BlockHeight> &obh) noexcept : bh(obh), t{BH} {}
     ~SubStatus() { destruct(); }
 
     SubStatus &operator=(const SubStatus &o) { copy(o); return *this; }
@@ -132,6 +146,11 @@ public:
         *dsp = std::move(od);
         return *this;
     }
+    SubStatus &operator=(const std::optional<BlockHeight> &obh) {
+        if (t != BH) construct(BH);
+        bh = obh;
+        return *this;
+    }
 
    bool operator==(const SubStatus &o) const {
         if (t != o.t) return false;
@@ -139,6 +158,7 @@ public:
         case NoValue: return true; // all NoValues are always equal
         case QBA: return qba == o.qba;
         case DSP: return *dsp == *o.dsp;
+        case BH: return bh == o.bh;
         }
     }
     bool operator!=(const SubStatus &o) const { return !(*this == o); }
@@ -151,8 +171,11 @@ public:
     QByteArray * byteArray() noexcept { return t == QBA ? &qba : nullptr; }
     const QByteArray * byteArray() const noexcept { return t == QBA ? &qba : nullptr; }
 
-    DSProof * dsproof()  noexcept { return t == DSP ? dsp.get() : nullptr; }
+    DSProof * dsproof() noexcept { return t == DSP ? dsp.get() : nullptr; }
     const DSProof * dsproof() const noexcept { return t == DSP ? dsp.get() : nullptr; }
+
+    const std::optional<BlockHeight> * blockHeight() const noexcept { return t == BH ? &bh : nullptr; }
+    std::optional<BlockHeight> * blockHeight() noexcept { return t == BH ? &bh : nullptr; }
 };
 
 /// Specialization of std::hash so we can use SubStatus with std::unordered_map, std::unordered_set, etc
@@ -160,7 +183,8 @@ template <> struct std::hash<SubStatus> {
     std::size_t operator()(const SubStatus &s) const {
         if (auto *ba = s.byteArray(); ba) return HashHasher{}(*ba);
         else if (auto *dsp = s.dsproof(); dsp) return DspHash::Hasher{}(dsp->hash);
-        return 0; // !has_value hashes to 0 always
+        else if (auto *bh = s.blockHeight(); bh && *bh) return Util::hashForStd(**bh);
+        return 0; // !this->has_value() and/or !bh->has_value() hashes to 0 always
     }
 };
 

--- a/src/SubsMgr.cpp
+++ b/src/SubsMgr.cpp
@@ -209,7 +209,7 @@ void SubsMgr::doNotifyAllPending()
         }
     }
     if (ctr || ctrSH) {
-        DebugM(__func__, ": ", ctr, Util::Pluralize(" client", ctr), ", ", ctrSH, Util::Pluralize(" scripthash", ctrSH),
+        DebugM(__func__, ": ", ctr, Util::Pluralize(" client", ctr), ", ", ctrSH, Util::Pluralize(" subscribables", ctrSH),
                " in ", t0.msecStr(4), " msec");
     }
 }

--- a/src/SubsMgr.cpp
+++ b/src/SubsMgr.cpp
@@ -192,7 +192,8 @@ void SubsMgr::doNotifyAllPending()
             // below emit sub->statusChanged(...) will just be a no-op.
             LockGuard g(sub->mut);
             const bool doemit = !sub->lastStatusNotified.has_value() || sub->lastStatusNotified != status;
-            // we basically cache 2 statuses but they are implicitly shared copies of the same memory so it's ok.
+            // we basically cache 2 statuses -- one for what we return immediately to new subs and one to
+            // keep track of not notifying twice on the same sub.
             sub->lastStatusNotified = status;
             if (useCache)
                 sub->cachedStatus = status;
@@ -568,6 +569,7 @@ auto SubsMgr::debug(const StatsParams &params) const -> Stats
                     LockGuard g2(sub->mut);
                     m2["count"] = qlonglong(sub->subscribedClientIds.size());
                     m2["lastStatusNotified"] = sub->lastStatusNotified.toVariant();
+                    m2["cachedStatus"] = sub->cachedStatus.toVariant();
                     m2["idleSecs"] = (Util::getTime() - sub->tsMsec)/1e3;
                     const auto & clients = sub->subscribedClientIds;
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)

--- a/src/SubsMgr.cpp
+++ b/src/SubsMgr.cpp
@@ -570,6 +570,8 @@ auto SubsMgr::debug(const StatsParams &params) const -> Stats
                         m2["lastStatusNotified"] = ba->toHex();
                     else if (auto *dsp = sub->lastStatusNotified.dsproof())
                         m2["lastStatusNotified"] = dsp->toVarMap();
+                    else if (auto *bh = sub->lastStatusNotified.blockHeight())
+                        m2["lastStatusNotified"] = *bh ? QVariant(qlonglong(**bh)) : QVariant{""};
                     else
                         m2["lastStatusNotified"] = QVariant{};
                     m2["idleSecs"] = (Util::getTime() - sub->tsMsec)/1e3;

--- a/src/SubsMgr.cpp
+++ b/src/SubsMgr.cpp
@@ -408,6 +408,7 @@ void SubsMgr::maybeCacheStatusResult(const HashX &sh, const SubStatus &status)
     else if (auto *dsp = status.dsproof(); dsp && !dsp->isComplete() && !dsp->isEmpty())
         // we only allow empty (default constructred) DSProofs or ones that are isComplete(), otherwise reject
         return;
+    // else .. we always cache status.blockHeight() ..
     SubRef sub = findExistingSubRef(sh);
     if (sub) {
         LockGuard g(sub->mut);
@@ -566,14 +567,7 @@ auto SubsMgr::debug(const StatsParams &params) const -> Stats
                 {
                     LockGuard g2(sub->mut);
                     m2["count"] = qlonglong(sub->subscribedClientIds.size());
-                    if (auto *ba = sub->lastStatusNotified.byteArray())
-                        m2["lastStatusNotified"] = ba->toHex();
-                    else if (auto *dsp = sub->lastStatusNotified.dsproof())
-                        m2["lastStatusNotified"] = dsp->toVarMap();
-                    else if (auto *bh = sub->lastStatusNotified.blockHeight())
-                        m2["lastStatusNotified"] = *bh ? QVariant(qlonglong(**bh)) : QVariant{""};
-                    else
-                        m2["lastStatusNotified"] = QVariant{};
+                    m2["lastStatusNotified"] = sub->lastStatusNotified.toVariant();
                     m2["idleSecs"] = (Util::getTime() - sub->tsMsec)/1e3;
                     const auto & clients = sub->subscribedClientIds;
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)

--- a/src/SubsMgr.cpp
+++ b/src/SubsMgr.cpp
@@ -209,7 +209,7 @@ void SubsMgr::doNotifyAllPending()
         }
     }
     if (ctr || ctrSH) {
-        DebugM(__func__, ": ", ctr, Util::Pluralize(" client", ctr), ", ", ctrSH, Util::Pluralize(" subscribables", ctrSH),
+        DebugM(__func__, ": ", ctr, Util::Pluralize(" client", ctr), ", ", ctrSH, Util::Pluralize(" subscribable", ctrSH),
                " in ", t0.msecStr(4), " msec");
     }
 }

--- a/src/SubsMgr.cpp
+++ b/src/SubsMgr.cpp
@@ -205,7 +205,7 @@ void SubsMgr::doNotifyAllPending()
             }
         } catch (const std::exception & e) {
             // Defensive programming here in case getFullStatus() or other functions throw (extremely unlikely)
-            Error() << "ERROR: Caught exception attempting to calculate status for scripthash: " << sh.toHex();
+            Error() << "ERROR: Caught exception attempting to calculate status for subscribable: " << sh.toHex();
         }
     }
     if (ctr || ctrSH) {
@@ -679,6 +679,12 @@ auto DSProofSubsMgr::getFullStatus(const HashX &txHash) const -> SubStatus
     return DSProof{}; // a SubStatus with a .isEmpty() indicates no proof for this txhash
 }
 
+TransactionSubsMgr::~TransactionSubsMgr() {}
+
+SubStatus TransactionSubsMgr::getFullStatus(const HashX &txHash) const
+{
+    return storage->getTxHeight(txHash);
+}
 
 #ifdef ENABLE_TESTS
 #include "App.h"

--- a/src/SubsMgr.cpp
+++ b/src/SubsMgr.cpp
@@ -556,7 +556,7 @@ std::unordered_set<HashX, HashHasher> SubsMgr::nonZombieKeysOlderThan(const int6
 auto SubsMgr::debug(const StatsParams &params) const -> Stats
 {
     QVariant ret;
-    if (params.contains("subs") || params.contains("dspsubs")) {
+    if (params.contains("subs") || params.contains("dspsubs") || params.contains("txsubs")) {
         QVariantMap subs;
         qulonglong collisions{}, largestBucket{}, medianBucket{}, medianNonzeroBucket{};
         {

--- a/src/SubsMgr.h
+++ b/src/SubsMgr.h
@@ -299,3 +299,20 @@ protected:
 private:
     void expireSubsNotInMempool(); // takes mempool lock in shared mode, called from a timer
 };
+
+class TransactionSubsMgr final : public SubsMgr {
+protected:
+    friend class ::Storage;
+    /// Only Storage can construct one of these -- Storage is guaranteed to remain alive at least as long as this instance.
+    TransactionSubsMgr(const std::shared_ptr<const Options> & opts, Storage * storage, const QString &name = "SubsMgr (Txs)")
+        : SubsMgr(opts, storage, name) {}
+public:
+    ~TransactionSubsMgr() override;
+
+    /// Thread-safe. Returns a SubStatus object which .has_value() and where .blockHeight() is not nullptr.
+    /// Will return an object with a *blockHeight() which is itself nullopt (default constructed) if the tx in question
+    /// is not known. Otherwise the **blockHeight() will be a height where 0=mempool and >0=confirmed_height.
+    ///
+    /// Note that this implicitly will take some of the Storage locks: blocksLock, blkInfoLock, and mempoolLock.
+    SubStatus getFullStatus(const HashX &txHash) const override;
+};

--- a/src/Util.h
+++ b/src/Util.h
@@ -955,6 +955,17 @@ namespace Util {
     /// If allowImplicitLoopback=true then "<port>" by itself is interpreted as "127.0.0.1:<port>"
     QPair<QString, quint16> ParseHostPortPair(const QString &hostColonPort, bool allowImplicitLoopback = false);
 
+    /// Tells you the size of a QByteArray::QArrayData object which each QByteArray that is not null has a pointer to.
+    /// This function basically tells you how much extra space a QByteArray takes up just by existing, beyond its base
+    /// sizeof(QByteArray) + .size()+1.
+    inline constexpr size_t qByteArrayPvtDataSize(bool isNull = false) {
+        static_assert (sizeof(decltype(std::declval<QByteArray>().size())) == sizeof(int),
+                       "Assumption here is that QByteArray uses ints for indexing (true in Qt5, not true in Qt6)");
+        constexpr size_t padding = sizeof(void *) > sizeof(int) ? sizeof(void *) - sizeof(int) : 0;
+        return isNull ? 0 // null uses a single shared object so basically 0 extra size
+                      : sizeof(int)*3 + padding + sizeof(void *); // not null -- QArrayData has 3 ints and 1 pointer (but pointer offset is padded for alignment on 64-bit)
+    }
+
 } // end namespace Util
 
 /// Kind of like Go's "defer" statement. Call a lambda (for clean-up code) at scope end.

--- a/src/VarInt.h
+++ b/src/VarInt.h
@@ -18,14 +18,17 @@
 //
 #pragma once
 
+#include "ByteView.h"
 #include "Span.h"
 
 #include <QByteArray>
 #include <QString>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <stdexcept>
 #include <type_traits>
 
@@ -39,20 +42,25 @@
 /// serialize the data originally. The serialized format is in little endian byte order.
 class VarInt
 {
-    QByteArray ba;
-
     /// The max payload length we support. Do not change this! Changing this value changes the binary format!
     static constexpr std::size_t maxBytes = 8u;
+public:
+    static constexpr auto maxSize = maxBytes + 1; // 1 extra byte for control byte
+private:
     static_assert (maxBytes == sizeof(std::uint64_t)); ///< If this ever doesn't hold, must be a very weird platform.
     static_assert (-1 == ~0, "2's complement architecture required"); ///< We assume 2's complement for signed
     /// All values <= 0xf7 (247) are taken verbatim (no control byte). First control value for payloadlen=1 is 0xf8
     static constexpr std::uint8_t b1max = 0xffu - maxBytes;
 
+    // default constructed value encapsulates the value 0
+    std::uint8_t sz = 1; ///< actual used bytes of arr below
+    std::array<std::byte, maxSize> arr = {std::byte{0}, };
+
+
     /// Returns the payload length if b validates, otherwise throws Exc.
     /// The returned value is always >= 0 and <= maxBytes.
-    template <typename Exc, typename BArray>
-    static std::size_t validate(const BArray & b, bool allowExtraBytesAtEnd = false) {
-        static_assert(sizeof(*b.data()) == 1);
+    template <typename Exc>
+    static constexpr std::size_t validate(const ByteView & b, bool allowExtraBytesAtEnd = false) {
         const int bsize = int(b.size());
         if (bsize <= 0)
             throw Exc("VarInt: Empty byte array");
@@ -64,38 +72,35 @@ class VarInt
         return std::size_t(payloadLen);
     }
 
+    struct Unchecked {};
     /// Unchecked constructor, used by fromBytes()
-    explicit VarInt(const QByteArray &b) : ba(b) {}
-    /// Unchecked constructor, used by fromBytes()
-    explicit VarInt(QByteArray &&b) : ba(std::move(b)) {}
+    explicit VarInt(Unchecked, const ByteView &b) noexcept {
+        sz = std::min(arr.size(), b.size());
+        std::memcpy(arr.data(), b.data(), sz);
+    }
 
 public:
     template <typename Int, std::enable_if_t<std::is_integral_v<Int> && !std::is_same_v<std::remove_cv_t<Int>, bool>, int> = 0>
-    VarInt(Int val) {
+    constexpr VarInt(const Int val) {
         using UInt = std::make_unsigned_t<Int>;
         static_assert (sizeof(UInt) <= maxBytes);
         static_assert (maxBytes <= 255u && maxBytes > 0u);
         const UInt uval(val);
-        uint_fast8_t nbytes;
-        if (val == 0)
-            nbytes = 1; // special case for val == 0, we must encode at least 1 byte of data
-        else {
+        uint_fast8_t nbytes = 1; // special case for val == 0, we must encode at least 1 byte of data
+        if (val != 0) {
             // scan to determine the number of bytes we need, setting nbytes to that value
             for (nbytes = maxBytes; nbytes > 0u; --nbytes) {
                 if (std::uint64_t(uval) & 0xffull << (nbytes-1ull)*8ull)
                     break;
             }
         }
-        std::byte *payload;
+        std::byte *payload = arr.data();
         if (nbytes > 1 || uval > b1max) {
-            // requires a payload, 1 byte(s) or more of data, we must prepend the control byte
-            ba = QByteArray(nbytes + 1, Qt::Uninitialized);
-            payload = reinterpret_cast<std::byte *>(ba.data());
+            sz = nbytes + 1; // this can never exceed 9
             *payload++ = std::byte(b1max + nbytes);
         } else if (nbytes == 1 && uval <= b1max) {
             // 1 byte of data, no control byte because value is <= 247
-            ba = QByteArray(1, Qt::Uninitialized);
-            payload = reinterpret_cast<std::byte *>(ba.data());
+            sz = 1;
         } else
             // this should never happen
             throw std::logic_error("VarInt internal error: Unexpected state! FIXME!");
@@ -104,23 +109,15 @@ public:
         }
     }
 
-    /// Construct an instance from raw bytes. May throw std::invalid_argument if b is of the wrong format, or is empty.
+    /// Construct an instance from raw bytes such as QByteArray bytes. May throw std::invalid_argument if b is of the
+    /// wrong format, or is empty.
     ///
     /// Note that b must note have extra data at the end. If deserializing a byte stream that may have more bytes at
     /// the end, use deserialize().
-    static VarInt fromBytes(const QByteArray &b) {
+    static VarInt fromBytes(const ByteView &b) {
         validate<std::invalid_argument>(b);
         // accepted, below c'tor takes a shallow copy
-        return VarInt(b);
-    }
-    /// Move-constructs an instance from raw bytes. May throw std::invalid_argument if b is of the wrong format, or is empty.
-    ///
-    /// Note that b must note have extra data at the end. If deserializing a byte stream that may have more bytes at
-    /// the end, use deserialize().
-    static VarInt fromBytes(QByteArray &&b) {
-        validate<std::invalid_argument>(b);
-        // accepted, move construct
-        return VarInt(std::move(b));
+        return VarInt{Unchecked{}, b};
     }
 
     /// Deserialize a byte sequence. May throw std::invalid_argument if b is of the wrong format or is empty.
@@ -128,39 +125,47 @@ public:
     /// On success, Span b is updated to point after the consumed byte(s).
     template<typename Byte, std::enable_if_t<sizeof(Byte) == 1 && !std::is_same_v<std::remove_cv_t<Byte>, bool>, int> = 0>
     static VarInt deserialize(Span<Byte> &b) {
-        const int byteLen = validate<std::invalid_argument>(b, true) + 1;
+        const std::size_t byteLen = validate<std::invalid_argument>(b, true) + 1;
         // accepted construct (takes a deep copy of bytes in span)
-        VarInt ret(QByteArray(reinterpret_cast<const char *>(const_cast<const Byte *>(b.data())), byteLen));
-        b = b.subspan(std::size_t(byteLen)); // uodate b (consume bytes)
+        const std::byte *spanAcceptedBytes = reinterpret_cast<const std::byte *>(const_cast<const Byte *>(b.data()));
+        VarInt ret(Unchecked{}, ByteView{spanAcceptedBytes, byteLen});
+        b = b.subspan(byteLen); // uodate b (consume bytes)
         return ret;
     }
 
-    VarInt() : ba(1, char(0)) {} // default c'tor: represent the value 0
-    VarInt(const VarInt &) = default;
-    VarInt(VarInt &&) = default;
-    VarInt &operator=(const VarInt &) = default;
-    VarInt &operator=(VarInt &&) = default;
+    constexpr VarInt() noexcept = default; // default c'tor: represents the value 0
+    constexpr VarInt(const VarInt &) noexcept = default;
+    constexpr VarInt(VarInt &&) noexcept = default;
+    constexpr VarInt &operator=(const VarInt &) noexcept = default;
+    constexpr VarInt &operator=(VarInt &&) noexcept = default;
 
     // lexicographical comparison based on raw bytes
-    bool operator==(const VarInt &o) const { return ba == o.ba; }
-    bool operator!=(const VarInt &o) const { return ba != o.ba; }
-    bool operator<(const VarInt &o) const { return ba < o.ba; }
-    bool operator>=(const VarInt &o) const { return ba >= o.ba; }
-    bool operator<=(const VarInt &o) const { return ba <= o.ba; }
-    bool operator>(const VarInt &o) const { return ba > o.ba; }
+    constexpr bool operator==(const VarInt &o) const noexcept { return byteView() == o.byteView(); }
+    constexpr bool operator!=(const VarInt &o) const noexcept { return byteView() != o.byteView(); }
+    constexpr bool operator< (const VarInt &o) const noexcept { return byteView() <  o.byteView(); }
+    constexpr bool operator>=(const VarInt &o) const noexcept { return byteView() >= o.byteView(); }
+    constexpr bool operator<=(const VarInt &o) const noexcept { return byteView() <= o.byteView(); }
+    constexpr bool operator> (const VarInt &o) const noexcept { return byteView() >  o.byteView(); }
 
-    const QByteArray & bytes() const { return ba; }
-    QString hex() const { return QString::fromUtf8(ba.toHex()); }
+    constexpr const std::byte *data() const noexcept { return arr.data(); }
+    constexpr std::size_t size() const noexcept { return sz; }
+
+    // view of raw serialized bytes
+    constexpr ByteView byteView() const noexcept { return ByteView{data(), size()}; }
+
+    QByteArray byteArray(bool deepCopy = true) const { return byteView().toByteArray(deepCopy); }
+    QString hex() const { return QString::fromUtf8(byteArray(false).toHex()); }
+
 
     /// Deserialize the VarInt, converting its data into the template return type.
     /// Note that this may throw std::overflow_error if the specified type would overflow
     /// and cannot hold the data in question.
     /// (NB: may throw std::logic_error if there are bugs in this code).
     template <typename Int>
-    std::enable_if_t<std::is_integral_v<Int> && !std::is_same_v<std::remove_cv_t<Int>, bool>, Int>
-    /* Int */ value() const {
-        const std::size_t payloadLen = validate<std::logic_error>(ba);
-        const std::byte * const payload = reinterpret_cast<const std::byte *>(ba.constData() + 1);
+    constexpr std::enable_if_t<std::is_integral_v<Int> && !std::is_same_v<std::remove_cv_t<Int>, bool>, Int>
+    /* constexpr Int */ value() const {
+        const std::size_t payloadLen = validate<std::logic_error>(byteView());
+        const std::byte * const payload = arr.data() + 1;
         if (payloadLen == 0) {
             // The control byte is the value itself; there is no payload, so take the byte before the payload
             // for the value and return it.


### PR DESCRIPTION
## Changes:

- Fulcrum version bumped to 1.5.0
- Protocol version bumped to 1.4.5
- Database has a new table, called `txhash2txnum` which is basically a glorified multi-hash-map whereby the key is 6 bytes from the txhash and the buckets are a list of `VarInt`, each entry corresponding to an offset in the txnum2txhash flat file. This allows us to lookup tx's by txid and figure out if they are confirmed or not and if so at what block height.
- This new index enables us to add a new facility: `blockchain.transaction.subscribe`, which resolves issue #32 .
- This new index also allows us to offer a new RPC: `blockchain.transaction.get_height`, so that clients can find out if a txid is confirmed, and if so, in which block. A height of 0 is returned if the tx is in the mempool.  A height of `null` is returned if the tx is unknown.
- The RPC method `blockchain.transaction.get_merkle` now no longer requires the second `height` argument (it can still be specified and it does make the RPC slightly faster in that case). Fulcrum now knows the confirmed height of any tx if it exists in the blockchain, so the second argument is just a performance hack and now is no longer required.

## Performance and disk space implications:

This new index eats about 1GB on testnet3 and between ~3 - ~5GB or so on mainnet (the variability in how much it eats is due to the way rocksdb works).  The index doesn't eat too much time in terms of the `addBlock` pipeline for synching -- rocksdb has incredibly fast inserts.  Even so, we added a new `CoTask` which doles the work out in parallel in the `addBlock` function to add to this index in another worker thread while we are busy processing the block in our `Controller` thread.

## Migration path & compatibility:

This index is implemented as a separate rocksdb database, which lives in the datadir under `txhash2txnum/`.

Servers will automatically build this index on startup from the existing `txnum2txhash` flat-file. Building it on testnet3 with an SSD takes ~1 minute and on mainnet from between 3 and 10 minutes, depending.

If downgrading from this version back to the 1.4.x or earlier series -- the new database is simply ignored by older versions. Admins can then later move back up to later Fulcrum and the index will be detected as "stale" on startup and rebuilt from scratch on first run.

