### PR TITLE
Add arm64 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: cpp
 compiler: gcc
+arch:
+  - amd64
+  - arm64
 os: linux
 dist: bionic
 jobs:
   fast_finish: true
   include:
     - os: linux
+    - arch:
+      - amd64
+      - arm64
       dist: bionic
       env: TARGET_OS=ubuntu
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ jobs:
   fast_finish: true
   include:
     - os: linux
-      arch:
-        - amd64
-        - arm64
+      arch: amd64
+      dist: bionic
+      env: TARGET_OS=ubuntu
+    - os: linux
+      arch: arm64
       dist: bionic
       env: TARGET_OS=ubuntu
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 language: cpp
 compiler: gcc
-arch:
-  - amd64
-  - arm64
 os: linux
 dist: bionic
 jobs:
   fast_finish: true
   include:
     - os: linux
-    - arch:
-      - amd64
-      - arm64
+      arch:
+        - amd64
+        - arm64
       dist: bionic
       env: TARGET_OS=ubuntu
     - os: osx

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:bionic
+FROM --platform=$BUILDPLATFORM ubuntu:bionic
 LABEL maintainer="Axel Gembe <derago@gmail.com>"
 
 ARG MAKEFLAGS
 
 RUN apt-get update -y && \
     apt-get install -y software-properties-common && \
-    add-apt-repository ppa:beineri/opt-qt-5.13.2-bionic && \
+    add-apt-repository ppa:mainnet-pat/opt-qt-5.13.2-bionic && \
     apt-get update -y && \
     apt-get install -y qt513base openssl && \
     apt-get install -y git build-essential pkg-config zlib1g-dev libbz2-dev libjemalloc-dev libjemalloc1 libzmq3-dev && \

--- a/contrib/docker/build.sh
+++ b/contrib/docker/build.sh
@@ -12,5 +12,5 @@ IMAGE_TAG="$1"
 here=$(dirname $(realpath "$0" 2> /dev/null || grealpath "$0"))
 . "$here"/../base.sh
 
-docker buildx build --build-arg MAKEFLAGS="-j $WORKER_COUNT" -t "$IMAGE_TAG" -f Dockerfile \
+docker buildx build --build-arg MAKEFLAGS="-j $WORKER_COUNT" -t "$IMAGE_TAG" -f contrib/docker/Dockerfile \
     --platform linux/arm64/v8,linux/amd64 --push "$here"/../..

--- a/contrib/docker/build.sh
+++ b/contrib/docker/build.sh
@@ -12,4 +12,5 @@ IMAGE_TAG="$1"
 here=$(dirname $(realpath "$0" 2> /dev/null || grealpath "$0"))
 . "$here"/../base.sh
 
-docker build --build-arg MAKEFLAGS="-j $WORKER_COUNT" -t "$IMAGE_TAG" -f contrib/docker/Dockerfile "$here"/../..
+docker buildx build --build-arg MAKEFLAGS="-j $WORKER_COUNT" -t "$IMAGE_TAG" -f Dockerfile \
+    --platform linux/arm64/v8,linux/amd64 --push "$here"/../..

--- a/contrib/travis/linux.ubuntu.before_install
+++ b/contrib/travis/linux.ubuntu.before_install
@@ -1,3 +1,3 @@
 #!/bin/sh
-sudo add-apt-repository -y ppa:beineri/opt-qt-5.13.2-bionic
+sudo add-apt-repository -y ppa:mainnet-pat/opt-qt-5.13.2-bionic
 sudo apt-get update -qq


### PR DESCRIPTION
Hi Calin,

I've got a new M1 mac and having an issue to natively run our mainnet.cash docker test harness. Docker fails to correctly emulate the intel fulcrum image on an arm processor.

This PR:

- adds building docker images for multiple architectures (currently intel, arm64) using docker buildx.
- temporary modifies the Dockerfile to use `ppa:mainnet-pat/opt-qt-5.13.2-bionic` which is a clone of previously used `ppa:beineri/opt-qt-5.13.2-bionic` but builds arm64 deb packages. Author is contacted to support this in their repo.
- adds librocksdb.a static lib built for arm64

The images are currently hosted at https://hub.docker.com/repository/docker/mainnet/fulcrum/tags

Would be great to have these changes in the upstream and images hosted on official docker hub page of Fulcrum

Cheers,
pat.