### PR TITLE
RPM: Set the noreplace for the config file

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,8 @@
+# RPM package
+
+
+# How build locally
+
+The RPM contains some macros that only rpkg understands.
+
+Fulcrum$ rpkg local --spec contrib/rpm/fulcrum.spec

--- a/contrib/rpm/fulcrum.spec
+++ b/contrib/rpm/fulcrum.spec
@@ -75,7 +75,7 @@ exit 0
 %doc README.md
 %license LICENSE.txt
 %{_mandir}/man1/fulcrum.1*
-%config %attr(640, root, fulcrum) %{_sysconfdir}/fulcrum.conf
+%config(noreplace) %attr(640, root, fulcrum) %{_sysconfdir}/fulcrum.conf
 %{_bindir}/fulcrum
 %attr(700, fulcrum, fulcrum) %{_sharedstatedir}/fulcrum
 %{_unitdir}/fulcrum.service


### PR DESCRIPTION
Set the noreplace flag for the config file /etc/fulcrum.conf. This stops upgrades from overwriting a modified config file.

