### PR TITLE
Add JSON-RPC batching + increase some resource defaults + bump version to 1.6.0

### DIFF
--- a/contrib/rpm/fulcrum.spec
+++ b/contrib/rpm/fulcrum.spec
@@ -1,5 +1,5 @@
 Name:    {{{ git_name name="fulcrum" }}}
-Version: 1.5.4
+Version: 1.6.0
 Release: {{{ git_version }}}%{?dist}
 Summary: A fast & nimble SPV server for Bitcoin Cash
 

--- a/doc/fulcrum-example-config.conf
+++ b/doc/fulcrum-example-config.conf
@@ -682,6 +682,24 @@ rpcpassword = hunter1
 # db_use_fsync = false
 
 
+# Maximum batch size (per IP) - 'max_batch' - DEFAULT: 345
+#
+# The maximum size of JSON-RPC batch requests to the server. Set this to 0
+# to unconditionally disable JSON-RPC batch requests server-wide.
+#
+# This configurable limit is in place as a DoS-prevention measure. If nonzero,
+# this limit is applied to non-whitelisted clients (clients whose IP is not
+# in `subnets_to_exclude_from_per_ip_limits`).
+#
+# The limit is a total limit for all batch requests active from a particular
+# IP address. For example, if max_batch = 99, and there are 4 connections from
+# a single IP address, with each client from that IP simultaneously sending a
+# batch request of size 25, then it's possible for 1 or more of the requests
+# to be rejected (100 > 99).
+#
+#max_batch = 345
+
+
 # Maximum transmission backlog size - 'max_buffer' - DEFAULT: 4000000
 #
 # The maximum size in bytes of the transmission buffer "backlog" (send and

--- a/doc/fulcrum-example-config.conf
+++ b/doc/fulcrum-example-config.conf
@@ -627,7 +627,7 @@ rpcpassword = hunter1
 # db_keep_log_file_num = 5
 
 
-# Max RocksDB Open Files - 'db_max_open_files' - DEFAULT: 20
+# Max RocksDB Open Files - 'db_max_open_files' - DEFAULT: 40
 #
 # The maximum number of database .sst files (table files) to keep open, per
 # database (there are 6 databases altogether used in Fulcrum). This limit can be
@@ -644,10 +644,10 @@ rpcpassword = hunter1
 #
 # Specify -1 for unlimited, or a value in the range 20, 2147483648.
 #
-# db_max_open_files = 20
+# db_max_open_files = 40
 
 
-# Max RocksDB Memory in MiB - 'db_mem' - DEFAULT: 420.0
+# Max RocksDB Memory in MiB - 'db_mem' - DEFAULT: 512.0
 #
 # Specifies roughly the maximum amount of memory to give to rocksdb. Larger
 # values offer better performance, at the expense of memory consumption. Note
@@ -660,7 +660,7 @@ rpcpassword = hunter1
 # works well on an SSD. If using an HDD for the datadir, you may want to set
 # this value higher than the default.
 #
-# db_mem = 420.0
+# db_mem = 512.0
 
 
 # RocksDB use "fsync" - 'db_use_fsync' - DEFAULT: false
@@ -700,7 +700,7 @@ rpcpassword = hunter1
 #max_batch = 345
 
 
-# Maximum transmission backlog size - 'max_buffer' - DEFAULT: 4000000
+# Maximum transmission backlog size - 'max_buffer' - DEFAULT: 8000000
 #
 # The maximum size in bytes of the transmission buffer "backlog" (send and
 # receive) per client. This limit is a simple sanity check against DoS and/or
@@ -726,7 +726,7 @@ rpcpassword = hunter1
 # connected clients using the 'maxbuffer' FulcrumAdmin command, and it will be
 # applied immediately to all connected clients.
 #
-#max_buffer = 4000000
+#max_buffer = 8000000
 
 
 # Max client connections per IP - 'max_clients_per_ip' - DEFAULT: 12
@@ -834,7 +834,7 @@ rpcpassword = hunter1
 #max_subs = 10000000
 
 
-# Maximum subscriptions (per-IP address) - 'max_subs_per_ip' - DEFAULT: 50000
+# Maximum subscriptions (per-IP address) - 'max_subs_per_ip' - DEFAULT: 75000
 #
 # The maximum number of script hash subscriptions per IP address. Note that IP
 # addresses matching 'subnets_to_exclude_from_per_ip_limits' will not be
@@ -844,7 +844,7 @@ rpcpassword = hunter1
 # If a client attempts to subscribe beyond this limit for all the connections
 # coming from their IP address, it will receive an error message.
 #
-#max_subs_per_ip = 50000
+#max_subs_per_ip = 75000
 
 
 # Peer IP uniqueness enforcement - 'peering_enforce_unique_ip' - DEFAULT: true
@@ -922,7 +922,7 @@ rpcpassword = hunter1
 #txhash_cache = 128
 
 
-# Work queue size - 'workqueue' - DEFAULT: 10000
+# Work queue size - 'workqueue' - DEFAULT: 15000
 #
 # The maximum size of the work queue. Requests from clients that require further
 # processing (such as get_merkle, get_history, listunspent, etc) all end up
@@ -934,7 +934,7 @@ rpcpassword = hunter1
 #
 # It is an error to set this parameter to less than 10.
 #
-#workqueue = 10000
+#workqueue = 15000
 
 
 # Work queue threads - 'worker_threads' - DEFAULT: 0 (= autodetect # of CPUs)

--- a/doc/unix-man-page.md
+++ b/doc/unix-man-page.md
@@ -1,6 +1,6 @@
-% FULCRUM(1) Version 1.5.4 | Fulcrum Manual
+% FULCRUM(1) Version 1.6.0 | Fulcrum Manual
 % Fulcrum is written by Calin Culianu (cculianu)
-% November 17, 2021
+% January 17, 2022
 
 # NAME
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -1247,6 +1247,17 @@ void App::parseArgs()
         Util::AsyncOnObject(this, []{ DebugM("config: compact-dbs = true"); });
     }
 
+    // conf: max_batch
+    if (conf.hasValue("max_batch")) {
+        bool ok{};
+        const unsigned val = unsigned(conf.intValue("max_batch", Options::defaultMaxBatch, &ok));
+        if (!ok || !options->isMaxBatchInRange(val))
+            throw BadArgs(QString("max_batch: please specify a value in the range [%1, %2]")
+                          .arg(options->maxBatchMin).arg(options->maxBatchMax));
+        options->maxBatch = val;
+        Util::AsyncOnObject(this, [val]{ DebugM("config: max_batch = ", val); });
+    }
+
     // parse --dump-*
     if (const auto outFile = parser.value("dump-sh"); !outFile.isEmpty()) {
         options->dumpScriptHashes = outFile; // we do no checking here, but Controller::startup will throw BadArgs if it cannot open this file for writing.

--- a/src/Common.h
+++ b/src/Common.h
@@ -39,7 +39,7 @@ struct InternalError : Exception { using Exception::Exception; ~InternalError() 
 struct BadArgs : Exception { using Exception::Exception; ~BadArgs() override; };
 
 #define APPNAME "Fulcrum"
-#define VERSION "1.5.4"
+#define VERSION "1.6.0"
 #ifdef QT_DEBUG
 inline constexpr bool isReleaseBuild() { return false; }
 #else

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -1086,7 +1086,7 @@ unsigned Controller::downloadTaskRecommendedThrottleTimeMsec(unsigned bnum) cons
             // mainnet
             if (bnum > 150'000) // beyond this height the blocks are starting to be big enough that we want to not eat memory.
                 maxBackLog = 250;
-            else if (bnum > 550'000) // beyond this height we may start to see 32MB blocks in the future
+            else if (bnum > 550'000 && !isCoinBTC()) // beyond this height we may start to see 32MB blocks in the future
                 maxBackLog = 100;
         } else if (sm->net == BTC::ScaleNet) {
             if (bnum > 10'000)
@@ -1096,7 +1096,7 @@ unsigned Controller::downloadTaskRecommendedThrottleTimeMsec(unsigned bnum) cons
         } else {
             // testnet
             if (bnum > 1'300'000) // beyond this height 32MB blocks may be common, esp. in the future
-                maxBackLog = 100;
+                maxBackLog = isCoinBTC() ? 250 : 100;
         }
 
         const int diff = int(bnum) - int(sm->ppBlkHtNext.load()); // note: ppBlkHtNext is not guarded by the lock but it is an atomic value, so that's fine.

--- a/src/Json/Json.cpp
+++ b/src/Json/Json.cpp
@@ -139,7 +139,8 @@ namespace {
     void Writer::writeVariant(const QVariant &v, unsigned prettyIndent, unsigned indentLevel, unsigned recursionDepth)
     {
         if (UNLIKELY(recursionDepth > MAX_RECURSION_DEPTH))
-            throw Json::NestingLimitExceeded("The nesting limit of 1024 was exceeded in writeVariant");
+            throw Json::NestingLimitExceeded(QString("The nesting limit of %1 was exceeded in %2")
+                                             .arg(QString::number(MAX_RECURSION_DEPTH), __func__));
 
         const auto typ = GetVarType(v);
 
@@ -372,7 +373,8 @@ namespace Json {
     static qsizetype estimateMemoryFootprint(const QVariant & v, unsigned recursionDepth)
     {
         if (UNLIKELY(recursionDepth > Writer::MAX_RECURSION_DEPTH))
-            throw Json::NestingLimitExceeded("The nesting limit of 1024 was exceeded in lowerBoundMemoryFootprint");
+            throw NestingLimitExceeded(QString("The nesting limit of %1 was exceeded in %2")
+                                       .arg(QString::number(Writer::MAX_RECURSION_DEPTH), __func__));
 
         const auto typ = GetVarType(v);
         qsizetype ret = sizeof(QVariant);

--- a/src/Json/Json.cpp
+++ b/src/Json/Json.cpp
@@ -369,13 +369,13 @@ namespace Json {
     }
 
     // Called by publicly visible estimateMemoryFootprint (this one tracks recursion depth)
-    static size_t estimateMemoryFootprint(const QVariant & v, unsigned recursionDepth)
+    static qsizetype estimateMemoryFootprint(const QVariant & v, unsigned recursionDepth)
     {
         if (UNLIKELY(recursionDepth > Writer::MAX_RECURSION_DEPTH))
             throw Json::NestingLimitExceeded("The nesting limit of 1024 was exceeded in lowerBoundMemoryFootprint");
 
         const auto typ = GetVarType(v);
-        size_t ret = sizeof(QVariant);
+        qsizetype ret = sizeof(QVariant);
 
         if (v.isNull()) {
             // Note that QString.isNull() in the QVariant can also satisfy this, so we must special-case this.
@@ -458,7 +458,7 @@ namespace Json {
         } // end switch
     }
 
-    size_t estimateMemoryFootprint(const QVariant & v) { return estimateMemoryFootprint(v, 0); }
+    qsizetype estimateMemoryFootprint(const QVariant & v) { return estimateMemoryFootprint(v, 0); }
 
 } // end namespace Json
 

--- a/src/Json/Json.h
+++ b/src/Json/Json.h
@@ -27,11 +27,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "Common.h"
 
+#include <QtGlobal> // for qsizetype (and other typedefs)
 #include <QByteArray>
 #include <QString>
 #include <QVariant>
 
-#include <cstdint>
 #include <optional>
 #include <stdexcept>
 #include <vector>
@@ -110,7 +110,7 @@ namespace Json {
     /// Note that if the QVariant contains types we don't support for serialization, they will
     /// be costed as simply sizeof(QVariant).
     /// May throw NestingLimitExceeded if the supplied QVariant has a recursive nesting depth larger than 1024.
-    extern size_t estimateMemoryFootprint(const QVariant &);
+    extern qsizetype estimateMemoryFootprint(const QVariant &);
 
     // --
     // -- Below are extra utility and other functions for querying the simdjson impl, checking the locale, etc.

--- a/src/Json/Json.h
+++ b/src/Json/Json.h
@@ -31,6 +31,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <QString>
 #include <QVariant>
 
+#include <cstdint>
 #include <optional>
 #include <stdexcept>
 #include <vector>
@@ -93,6 +94,7 @@ namespace Json {
     enum class SerOption { NoBareNull, BareNullOk };
     /// Serialization, may throw Error, may throw std::exception on low-level error (bad_alloc, etc).
     /// Will throw also if given an empty QVariant{}, unless BareNullOk is specified.
+    /// May throw NestingLimitExceeded if the supplied QVariant has a recursive nesting depth larger than 1024.
     /// If compact = true, the generated JSON will have no whitespace between tokens.
     /// If compact = false, the generated JSON will have newlines and 4-spaces as indentation per indentation level.
     extern QByteArray toUtf8(const QVariant &, bool compact = false, SerOption = SerOption::BareNullOk);
@@ -100,8 +102,15 @@ namespace Json {
     /// Low-level function -- like toUtf8() but lets you control the indentation level, etc.
     /// prettyIndent = 0 - compact (no whitespace), otherwise it will be the amount to indent at each level
     /// May throw Error or std::exception, or return an empty QByteArray on error.
+    /// May throw NestingLimitExceeded if the supplied QVariant has a recursive nesting depth larger than 1024.
     extern QByteArray serialize(const QVariant &v, unsigned prettyIndent = 0, unsigned indentLevel = 0);
 
+    /// Returns a rough estimate of the amount of memory a particular JSON-compatible QVariant
+    /// consumes.  This is a Fulcrum extension (which may end up ported to the main lib -Calin).
+    /// Note that if the QVariant contains types we don't support for serialization, they will
+    /// be costed as simply sizeof(QVariant).
+    /// May throw NestingLimitExceeded if the supplied QVariant has a recursive nesting depth larger than 1024.
+    extern size_t estimateMemoryFootprint(const QVariant &);
 
     // --
     // -- Below are extra utility and other functions for querying the simdjson impl, checking the locale, etc.

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -172,6 +172,8 @@ QVariantMap Options::toMap() const
     m["max_reorg"] = maxReorg;
     // txhash_cache
     m["txhash_cache"] = txHashCacheBytes / 1e6; // this comes in as a MB value from config, so spit it back out in the same MB unit
+    // max_batch
+    m["max_batch"] = maxBatch;
     return m;
 }
 

--- a/src/Options.h
+++ b/src/Options.h
@@ -262,8 +262,11 @@ public:
     // config: max_batch
     /// Per-IP limit on the size of batch requests. Note that all extant batch requests from a given IP together
     /// cannot exceed this limit at any one time.  This limit is not applied to clients in the per-ip exclusion list.
-    /// If this limit is set to 0, then batching is disabled for the server.
-    static constexpr unsigned defaultMaxBatch = 200, ///< TODO: tweak this number. Is it too high? Too low? Follow-up with BlueWallet team?
+    /// If this limit is set to 0, then batching is disabled for the server (even for whitelisted clients).
+    /// Note: we set the default to 345 here because BlueWallet sends batches of 200, 100, and 45 depending on the
+    /// request and it's not clear to me if it sends all 3 of them at once or if it sends them in series.
+    /// TODO: Follow up with BlueWallet team on this.  I'd like to set this limit lower (perhaps to 200).
+    static constexpr unsigned defaultMaxBatch = 345,
                               maxBatchMin = 0,
                               maxBatchMax = 100'000; ///< This 100k limit is ridiculous, but we will allow it.
     static constexpr bool isMaxBatchInRange(unsigned n) { return n >= maxBatchMin && n <= maxBatchMax; }

--- a/src/Options.h
+++ b/src/Options.h
@@ -137,7 +137,7 @@ public:
     bool isAddrInPerIPLimitExcludeSet(const QHostAddress & addr, Subnet * matched = nullptr) const;
 
     // Max history & max buffer
-    static constexpr int defaultMaxBuffer = 4'000'000, maxBufferMin = 64'000, maxBufferMax = 100'000'000;
+    static constexpr int defaultMaxBuffer = 8'000'000, maxBufferMin = 64'000, maxBufferMax = 100'000'000;
     static constexpr int defaultMaxHistory = 125'000, maxHistoryMin = 1000, maxHistoryMax = 25'000'000;
 
     static constexpr bool isMaxBufferSettingInBounds(int m) { return m >= maxBufferMin && m <= maxBufferMax; }
@@ -174,9 +174,9 @@ public:
     /// Comes from a triplet in config, if specified e.g.: "bitcoind_throttle = 50, 20, 10"
     AtomicStruct<BdReqThrottleParams> bdReqThrottleParams;
 
-    static constexpr int64_t defaultMaxSubsPerIP = 50'000, maxSubsPerIPMin = 500, maxSubsPerIPMax = std::numeric_limits<int>::max()/2; // 50k, 500, 10^30 (~1bln) respectively
+    static constexpr int64_t defaultMaxSubsPerIP = 75'000, maxSubsPerIPMin = 500, maxSubsPerIPMax = std::numeric_limits<int>::max()/2; // 75k, 500, 10^30 (~1bln) respectively
     static constexpr int64_t defaultMaxSubsGlobally = 10'000'000, maxSubsGloballyMin = 5000, maxSubsGloballyMax = std::numeric_limits<int>::max(); // 10 mln, 5k, 10^31 (~2bln) respectively
-    int64_t maxSubsPerIP = defaultMaxSubsPerIP; // 50k subs per IP ought to be plenty. User can set this in `max_subs_per_ip` in conf.
+    int64_t maxSubsPerIP = defaultMaxSubsPerIP; // 75k subs per IP ought to be plenty. User can set this in `max_subs_per_ip` in conf.
     int64_t maxSubsGlobally = defaultMaxSubsGlobally; // 10 million subs max globally.  User can set this in `max_subs` in conf.
     static constexpr bool isMaxSubsPerIPSettingInBounds(int64_t m) { return m >= maxSubsPerIPMin && m <= maxSubsPerIPMax; }
     static constexpr bool isMaxSubsGloballySettingInBounds(int64_t m) { return m >= maxSubsGloballyMin && m <= maxSubsGloballyMax; }
@@ -184,7 +184,7 @@ public:
     QString dumpScriptHashes;  ///< if specified, a file path to which to dump all scripthashes as JSON, corresponds to --dump-sh CLI arg
 
     struct DBOpts {
-        static constexpr int defaultMaxOpenFiles = 20, maxOpenFilesMin = 20, maxOpenFilesMax = std::numeric_limits<int>::max();
+        static constexpr int defaultMaxOpenFiles = 40, maxOpenFilesMin = 20, maxOpenFilesMax = std::numeric_limits<int>::max();
         /// comes from config db_max_open_files -- default in rocksdb is -1 meaning unlimited.
         /// See: https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB#indexes-and-filter-blocks
         int maxOpenFiles = defaultMaxOpenFiles;
@@ -195,7 +195,7 @@ public:
         unsigned keepLogFileNum = defaultKeepLogFileNum;
         static constexpr bool isKeepLogFileNumInBounds(int64_t k) { return k >= int64_t(minKeepLogFileNum) && k <= int64_t(maxKeepLogFileNum); }
 
-        static constexpr size_t defaultMaxMem = 420 * 1024 * 1024, maxMemMin = 50 * 1024 * 1024, maxMemMax = std::numeric_limits<size_t>::max();
+        static constexpr size_t defaultMaxMem = 512 * 1024 * 1024, maxMemMin = 50 * 1024 * 1024, maxMemMax = std::numeric_limits<size_t>::max();
         size_t maxMem = defaultMaxMem;
         static constexpr bool isMaxMemInBounds(size_t mem) { return mem >= maxMemMin && mem <= maxMemMax; }
 

--- a/src/Options.h
+++ b/src/Options.h
@@ -258,6 +258,16 @@ public:
     // CLI: --compact-dbs
     /// If specified, we compact all of the databases on startup
     bool compactDBs = false;
+
+    // config: max_batch
+    /// Per-IP limit on the size of batch requests. Note that all extant batch requests from a given IP together
+    /// cannot exceed this limit at any one time.  This limit is not applied to clients in the per-ip exclusion list.
+    /// If this limit is set to 0, then batching is disabled for the server.
+    static constexpr unsigned defaultMaxBatch = 200, ///< TODO: tweak this number. Is it too high? Too low? Follow-up with BlueWallet team?
+                              maxBatchMin = 0,
+                              maxBatchMax = 100'000; ///< This 100k limit is ridiculous, but we will allow it.
+    static constexpr bool isMaxBatchInRange(unsigned n) { return n >= maxBatchMin && n <= maxBatchMax; }
+    unsigned maxBatch = defaultMaxBatch;
 };
 
 /// A class encapsulating a simple read-only config file format.  The format is similar to the bitcoin.conf format

--- a/src/Options.h
+++ b/src/Options.h
@@ -265,7 +265,6 @@ public:
     /// If this limit is set to 0, then batching is disabled for the server (even for whitelisted clients).
     /// Note: we set the default to 345 here because BlueWallet sends batches of 200, 100, and 45 depending on the
     /// request and it's not clear to me if it sends all 3 of them at once or if it sends them in series.
-    /// TODO: Follow up with BlueWallet team on this.  I'd like to set this limit lower (perhaps to 200).
     static constexpr unsigned defaultMaxBatch = 345,
                               maxBatchMin = 0,
                               maxBatchMax = 100'000; ///< This 100k limit is ridiculous, but we will allow it.

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -671,7 +671,7 @@ namespace RPC {
     auto ConnectionBase::processObject(QVariantMap && vmap) -> ProcessObjectResult
     {
         auto ret = processObject_internal(std::move(vmap));
-        if (!ret.error) lastGood = Util::getTime(); // update "lastGood" as this is used to determine if stale or not.
+        if (ret.message) lastGood = Util::getTime(); // update "lastGood" as this is used to determine if stale or not.
         return ret;
     }
 

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -415,7 +415,7 @@ namespace RPC {
     bool ConnectionBase::batchResponseFilter(const Message & msg)
     {
         // first, see if the response corresponds to an extant batch request
-        for (auto * batch : extantBatchProcessors)
+        for (auto * batch : qAsConst(extantBatchProcessors))
             if (batch->acceptResponse(msg))
                 return true;
         return false;
@@ -465,7 +465,7 @@ namespace RPC {
                 // Note: This branch can only be taken if batchPermitted == true
                 // Handle error immediately. Note that older Fulcrum (or Fulcrum with batchinPermitted = false)
                 // would throw Json::Error here, which technically isn't quite correct.  As per JSON-RPC 2.0 specs,
-                // the Invalid request error should happen when a request isn't properly formatted or is of the wrongt
+                // the Invalid request error should happen when a request isn't properly formatted or is of the wrong
                 // JSON type.
                 throw InvalidRequest{};
             }
@@ -508,7 +508,7 @@ namespace RPC {
                 Error() << "Deleted extant batch processor with id " << bpId
                         << ", but the passed-in QObject pointer differs from the pointer in our table! FIXME!";
             }
-        }, Qt::QueuedConnection);
+        });
         extantBatchProcessors[batch->id] = batch;
         connect(batch, &BatchProcessor::finished, this, [this, bpId = batch->id]{
             if (auto *batch = extantBatchProcessors.take(bpId))

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -373,7 +373,7 @@ namespace RPC {
 
             // first, see if the error response corresponds to an extant batch request
             if (batchResponseFilter(m))
-                // an extant batch slurped up this response. Don't sned it to client.
+                // an extant batch slurped up this response. Don't send it to client.
                 return;
 
             // otherwise produce some Json right now and send it out to the client
@@ -402,7 +402,7 @@ namespace RPC {
 
             // first, see if the response corresponds to an extant batch request
             if (batchResponseFilter(m))
-                // an extant batch slurped up this response. Don't sned it to client.
+                // an extant batch slurped up this response. Don't send it to client.
                 return;
 
             // otherwise produce some Json right now and send it out to the client

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -1138,6 +1138,9 @@ namespace RPC {
         }
         if (batch.hasNext()) {
             if (conn.isReadPaused()) {
+                // ElectrumConnection subclasses may enter this "read paused" state when the bitcoind request queue
+                // backs up. We respect that flag and pause processing. We will be signalled to resume via the
+                // `readPausedStateChanged` signal when the backlog clears up in the near future.
                 DebugM(objectName(), " paused on batch item ", batch.nextItem + 1, ", returning early");
                 isProcessingPaused = true;
                 return;

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -519,6 +519,7 @@ namespace RPC {
             throw BatchLimitExceeded();
         }
         connect(batch, &QObject::destroyed, this, [this, bpId = batch->id](QObject *o) {
+            // NB: Qt doesn't deliver this signal to us if `this` is no longer is a ConnectionBase * (which is good)
             if (auto *ptr = extantBatchProcessors.take(bpId); UNLIKELY(ptr && ptr != o)) {
                 // this should never happen
                 Error() << "Deleted extant batch processor with id " << bpId

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -465,7 +465,7 @@ namespace RPC {
                 }
             } else if (var.canConvert<QVariantList>()) {
                 // Note: This branch can only be taken if batchPermitted == true
-                enqueueNewBatch(var.toList()); // This may throw InvalidRequest if list is empty, or BatchLimitExceeded
+                enqueueNewBatch(var.toList()); // This may throw InvalidRequest (if list is empty), or BatchLimitExceeded
                 return;
             } else {
                 // Note: This branch can only be taken if batchPermitted == true

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -523,7 +523,7 @@ namespace RPC {
             if (auto *batch = extantBatchProcessors.take(bpId))
                 batch->deleteLater();
         });
-        // start the batch from event loop  after the current event loop stack returns
+        // start the batch from event loop after the current event loop stack returns
         Util::AsyncOnObject(batch, [batch]{ batch->process(); });
     }
 

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -435,7 +435,7 @@ namespace RPC {
         }
         if (batchZombies.contains(msg.id)) {
             batchZombies.remove(msg.id);
-            DebugM(prettyName(), ": message id \"", msg.id.toString(), "\" found in batchZombies.",
+            DebugM(objectName(), ": message id \"", msg.id.toString(), "\" found in batchZombies.",
                    " Removed and message filtered. batchZombies size now: ", batchZombies.size());
             return true;
         }

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -1144,7 +1144,7 @@ namespace RPC {
     void BatchProcessor::process()
     {
         if (done) {
-            DebugM(objectName(), " ", __func__, ", done = true, aborting early...");
+            DebugM(objectName(), " ", __func__, ", done = true, aborting early ...");
             return;
         }
         if (UNLIKELY(conn.ignoreNewIncomingMessages)) {

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -509,7 +509,7 @@ namespace RPC {
     {
         bool doDisconnect = errorPolicy & ErrorPolicyDisconnect;
         if (errorPolicy & ErrorPolicySendErrorMessage) {
-            emit sendError(doDisconnect,code, message.left(120), msgId);
+            emit sendError(doDisconnect, code, message.left(120), msgId);
             if (!doDisconnect)
                 emit peerError(id, lastPeerError=message);
             doDisconnect = false; // if was true, already enqueued graceful disconnect after error reply, if was false, no-op here
@@ -1294,14 +1294,15 @@ namespace RPC {
         } else {
             // This branch is taken when we have sent out all the requests to the observer(s) but we haven't yet
             // received all the responses we expect. For now, we just time-out the batch request after 20 seconds.
-            constexpr int timeoutSec = 20; // TODO: have this come from config?!
+            constexpr int timeoutSec = 20; // We hard-code this value for now.
             DebugM(objectName(), ": lifecycle state is now idle");
             callOnTimerSoonNoRepeat(timeoutSec * 1000, "+InactivityTimeout", [this, timeoutSec]{
                 Error() << objectName() << ": timed out after not receiving a batch response for "
                         << timeoutSec << " seconds.";
+                done = true;
                 emit conn.sendError(true, Code_InternalError, "Batch request timed out");
                 conn.status = conn.Bad;
-                this->deleteLater();
+                emit finished();
             });
         }
     }

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -365,7 +365,7 @@ namespace RPC {
         {
             Message m = Message::makeError(code, msg, reqId, v1);
 
-            // first, see if the response corresponds to an extant batch request
+            // first, see if the error response corresponds to an extant batch request
             if (batchResponseFilter(m))
                 // an extant batch slurped up this response. Don't sned it to client.
                 return;
@@ -1203,7 +1203,6 @@ namespace RPC {
 
     bool BatchProcessor::acceptResponse(const Message &m)
     {
-        if (!m.isResponse() && !m.isError()) return false;
         if (auto it = batch.submittedRequests.find(m.id); it != batch.submittedRequests.end()) {
             batch.submittedRequests.erase(it);
             batch.answeredRequests.insert(m.id);

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -809,11 +809,11 @@ namespace RPC {
     {
         if (checkSetGetWebSocket()) {
             // in websocket mode we don't wrap anything -- it's already framed.
-            return d;
+            return std::move(d);
         }
         // regular classic Electrum Cash socket -- newline delimited.
         d.append(QByteArrayLiteral("\r\n"));
-        return d;
+        return std::move(d);
     }
 
     /* --- HttpConnection --- */

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -524,9 +524,6 @@ namespace RPC {
     void ConnectionBase::enqueueNewBatch(QVariantList && varList)
     {
         // handle Batch request -- add it to the extant batches
-
-        // TODO: limit the number of extant batches here, or the complexity of any single batch
-
         if (varList.empty())
             // empty batch lists are a JSON-RPC error
             throw InvalidRequest();
@@ -654,7 +651,6 @@ namespace RPC {
                 throw InvalidRequest("Invalid JSON");
             }
         } catch (const Exception &e) {
-            // TODO: clean this up. It's rather inelegant. :/
             const bool wasUnk = dynamic_cast<const UnknownMethod *>(&e);
             const bool wasInv = dynamic_cast<const InvalidRequest *>(&e) || dynamic_cast<const InvalidError *>(&e);
             const bool wasInvParms = dynamic_cast<const InvalidParameters *>(&e);

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -1122,7 +1122,8 @@ namespace RPC {
             return;
         }
         if (batch.hasNext()) {
-            DebugM(objectName(), " processing batch item ", batch.nextItem + 1);
+            DebugM(objectName(), " processing batch item ", batch.nextItem + 1, ", memory footprint is now: ",
+                   Json::estimateMemoryFootprint(batch.items));
             auto var = batch.getNextAndIncrement();
             const auto origSize = batch.responses.size();
             bool gotDisconnectFlag = false;
@@ -1165,7 +1166,7 @@ namespace RPC {
             }
             AGAIN();
         } else if (batch.isComplete()) {
-            DebugM(objectName(), " completed");
+            DebugM(objectName(), " completed", ", memory footprint is now: ", Json::estimateMemoryFootprint(batch.items));
             QVariantList l;
             QVariantList::size_type errCt = 0;
             for (const auto &msg : qAsConst(batch.responses)) {

--- a/src/RPC.h
+++ b/src/RPC.h
@@ -394,13 +394,13 @@ namespace RPC {
         bool strict = false; // if true, we will be more strict and reject some malformed JSON-RPC messages
         bool batchPermitted = false; // if true, we will accept JSON-RPC Batches
 
-        QString lastPeerError;
-        quint64 nRequestsSent = 0, nNotificationsSent = 0, nResultsSent = 0, nErrorsSent = 0;
-        quint64 nErrorReplies = 0, nUnansweredLifetime = 0;
-
         /// New in 1.0.1: This is latched to true in Client::on_disconnect to signal that the client is being
         /// disconnected and to just throw away any future messages from this client.
         bool ignoreNewIncomingMessages = false;
+
+        QString lastPeerError;
+        quint64 nRequestsSent = 0, nNotificationsSent = 0, nResultsSent = 0, nErrorsSent = 0;
+        quint64 nErrorReplies = 0, nUnansweredLifetime = 0;
 
         /// Returns true if `msgId` is in any of the extantBatchProcessors in either the submitted or answered request set.
         [[nodiscard]] bool hasMessageIdInBatchProcs(const Message::Id &msgId) const;
@@ -457,8 +457,8 @@ namespace RPC {
 
         ConnectionBase & conn;
         Batch batch;
-        bool done = false;
         const Tic t0;
+        bool done = false;
         bool isProcessingPaused = false;
 
     public:
@@ -506,8 +506,8 @@ namespace RPC {
         QByteArray wrapForSend(QByteArray &&) override;
 
     private:
-        bool memoryWasteTimerActive = false;  ///< inticates the DoS protection timer is active, used by memoryWasteDoSProtection
         qint64 memoryWasteThreshold = -1; ///< gets lazy-initialized in memoryWasteDoSProtection below
+        bool memoryWasteTimerActive = false;  ///< inticates the DoS protection timer is active, used by memoryWasteDoSProtection
         void memoryWasteDoSProtection(); ///< must be called from on_readyRead only.
 
         bool readPaused = false;

--- a/src/RPC.h
+++ b/src/RPC.h
@@ -420,7 +420,7 @@ namespace RPC {
         /// The number of responses in the batch response that were error responses.
         QVariantList::size_type errCt = 0;
 
-        QSet<RPC::Message::Id> submittedRequests, answeredRequests;
+        QSet<RPC::Message::Id> unansweredRequests, answeredRequests;
         /// Responses enqueued for sending back to the client, may also include error responses aside from results
         QVector<Message> responses;
 
@@ -444,7 +444,8 @@ namespace RPC {
 
     /// An individual batch request is managed by this object. Instances of this class are always children of
     /// `ConnectionBase`. They  appear in the ConnectionBase parent's `extantBatchProcessors` table.
-    class BatchProcessor : public QObject, public IdMixin, public ProcessAgainMixin, public TimersByNameMixin
+    class BatchProcessor : public QObject, public IdMixin, public ProcessAgainMixin, public TimersByNameMixin,
+                           public StatsMixin
     {
         Q_OBJECT
 
@@ -463,6 +464,9 @@ namespace RPC {
 
         const Batch & getBatch() const { return batch; }
         bool isFinished() const { return done; }
+
+    protected:
+        Stats stats() const override;
 
     signals:
         void finished();

--- a/src/RPC.h
+++ b/src/RPC.h
@@ -33,7 +33,7 @@
 
 #include <memory>
 #include <optional>
-#include <utility> // for std::pair
+#include <utility> // for std::pair, std::move
 
 namespace WebSocket { class Wrapper; } ///< fwd decl
 
@@ -402,9 +402,6 @@ namespace RPC {
         /// disconnected and to just throw away any future messages from this client.
         bool ignoreNewIncomingMessages = false;
 
-        /// Table used to store the extant batch processors running.
-        QHash<IdMixin::Id, BatchProcessor *> extantBatchProcessors;
-
         /// Returns true if `msgId` is in any of the extantBatchProcessors in either the submitted or answered request set.
         [[nodiscard]] bool hasMessageIdInBatchProcs(const Message::Id &msgId) const;
 
@@ -416,6 +413,9 @@ namespace RPC {
         [[nodiscard]] virtual bool canAcceptBatch(BatchProcessor *) { return true; }
 
     private:
+        /// Table used to store the extant batch processors running.
+        QHash<IdMixin::Id, BatchProcessor *> extantBatchProcessors;
+
         // Internally called by processObject()
         [[nodiscard]] ProcessObjectResult processObject_internal(QVariantMap &&);
         // Internally called by _sendResult and _sendError

--- a/src/RPC.h
+++ b/src/RPC.h
@@ -311,7 +311,7 @@ namespace RPC {
         /// If the batch limit has been exceeded
         struct BatchLimitExceeded : public BadPeer { using BadPeer::BadPeer; };
 
-        static constexpr int MAX_UNANSWERED_REQUESTS = 20000; ///< TODO: tune this down. For testing we leave this high for now.
+        static constexpr int MAX_UNANSWERED_REQUESTS = 20000; ///< TODO: tune this down?
 
         /// Subclasses, such as ElectrumConnection, reimplement this
         virtual bool isReadPaused() const { return false; }
@@ -432,6 +432,8 @@ namespace RPC {
         // Internally called to enqueue a new batch -- this may throw InvalidRequest if the QVariantList is empty
         void enqueueNewBatch(QVariantList &&);
     };
+
+    inline constexpr bool debugBatchExtra = false; ///< if true, Debug() log will print extra info for the batch processing feature
 
     /// Structure to hold a "batch request" context
     struct Batch

--- a/src/RPC.h
+++ b/src/RPC.h
@@ -441,17 +441,7 @@ namespace RPC {
         QVector<Message> responses;
 
         bool hasNext() const { return nextItem < items.size(); }
-
-        QVariant getNextAndIncrement() {
-            QVariant ret;
-            if (hasNext()) {
-                auto & v = items[nextItem++];
-                ret = v;
-                v.clear(); // consume array member right away to free up mmemory
-            }
-            return ret;
-        }
-
+        QVariant getNextAndIncrement();
         bool isComplete() const { return !hasNext() && skippedCt + responses.size() >= items.size(); }
 
         Batch() = default;

--- a/src/RPC.h
+++ b/src/RPC.h
@@ -378,7 +378,7 @@ namespace RPC {
             /// Send an error RPC message on protocol errors.
             /// If this is set and ErrorPolicyDisconnect is set, the disconnect will be graceful.
             /// Note that within a batch request this flag is ignored and errors are always sent
-            /// inside the batch response array (as psr JSON-RPC spec).
+            /// inside the batch response array (as per JSON-RPC spec).
             ErrorPolicySendErrorMessage = 1,
             /// Disconnect on RPC protocol errors. If this is set along with ErrorPolicySendErrorMessage,
             /// the disconnect will be graceful.

--- a/src/RPC.h
+++ b/src/RPC.h
@@ -419,6 +419,10 @@ namespace RPC {
     private:
         /// Table used to store the extant batch processors running.
         QHash<IdMixin::Id, BatchProcessor *> extantBatchProcessors;
+        /// Message id's for "batch zombies". That is, messages that were emitted via gotMessage() but
+        /// for which the batch processor was killed before a response was generated asynchronously.  We
+        /// need to filter these out from the client, to avoid a buggy corner case.
+        QSet<Message::Id> batchZombies;
 
         // Internally called by processObject()
         [[nodiscard]] ProcessObjectResult processObject_internal(QVariantMap &&);

--- a/src/RPC.h
+++ b/src/RPC.h
@@ -412,6 +412,9 @@ namespace RPC {
         ///   will begin processing when the current event loop becomes free.  Reimplemented in the `Client` subclass.
         [[nodiscard]] virtual bool canAcceptBatch(BatchProcessor *) { return true; }
 
+        /// This is called internally by either processJson() or by the BatchProcessor when it is killed.
+        void on_processJsonFailure(int code, const QString & message, const Message::Id &msgId = {});
+
     private:
         /// Table used to store the extant batch processors running.
         QHash<IdMixin::Id, BatchProcessor *> extantBatchProcessors;
@@ -460,6 +463,7 @@ namespace RPC {
         const Tic t0;
         bool done = false;
         bool isProcessingPaused = false;
+        bool killed = false;
 
     public:
         explicit BatchProcessor(ConnectionBase & parent, Batch && batch);
@@ -471,6 +475,8 @@ namespace RPC {
 
         const Batch & getBatch() const { return batch; }
         bool isFinished() const { return done; }
+
+        void killForExceedngLimit() { killed = true; }
 
     protected:
         Stats stats() const override;

--- a/src/RPC.h
+++ b/src/RPC.h
@@ -109,7 +109,7 @@ namespace RPC {
 
         // -- DATA --
 
-        Id id; ///< guaranteed to be either string, qint64, or nullptr
+        Id id; ///< guaranteed to be either string, qint64, or null
         QString method; /**< methodName extracted from data['method'] if it was present. If this is empty then no
                              'method' key was present in JSON. May also contain the "matched" method on a response
                              object where we matched the id to a method we knew about in Connection::idMethodMap. */
@@ -255,8 +255,7 @@ namespace RPC {
             struct Error {
                 int code{};
                 QString message;
-                bool disconnect{};
-                Error(int c, const QString & m, bool d) : code(c), message(m), disconnect(d) {}
+                Error(int c, const QString & m) : code(c), message(m) {}
             };
             // only 0 or 1 of the below 2 optionals will ever be valid at a time.
             std::optional<Error> error;
@@ -418,8 +417,8 @@ namespace RPC {
         /// The number of `items` that we have processed thus far that are notifications or that don't warrant a
         /// response in the batch response.
         QVariantList::size_type skippedCt = 0;
-        /// The number of responses that contained "disconnect" errors (there the disconnect flag is set)
-        QVariantList::size_type disconnectErrCt = 0;
+        /// The number of responses in the batch response that were error responses.
+        QVariantList::size_type errCt = 0;
 
         QSet<RPC::Message::Id> submittedRequests, answeredRequests;
         /// Responses enqueued for sending back to the client, may also include error responses aside from results

--- a/src/RPC.h
+++ b/src/RPC.h
@@ -344,13 +344,13 @@ namespace RPC {
     protected slots:
         /// Actual implentation that prepares the request. Is connected to sendRequest() above. Runs in this object's
         /// thread context. Eventually calls send() -> do_write() (from superclass).
-        virtual void _sendRequest(const RPC::Message::Id & reqid, const QString &method, const QVariantList & params = QVariantList());
+        void _sendRequest(const RPC::Message::Id & reqid, const QString &method, const QVariantList & params = QVariantList());
         // ditto for notifications
-        virtual void _sendNotification(const QString &method, const QVariant & params);
+        void _sendNotification(const QString &method, const QVariant & params);
         /// Actual implementation of sendError, runs in our thread context.
-        virtual void _sendError(bool disconnect, int errorCode, const QString &message, const RPC::Message::Id &reqid = Message::Id());
+        void _sendError(bool disconnect, int errorCode, const QString &message, const RPC::Message::Id &reqid = Message::Id());
         /// Actual implementation of sendResult, runs in our thread context.
-        virtual void _sendResult(const RPC::Message::Id & reqid, const QVariant & result = QVariant());
+        void _sendResult(const RPC::Message::Id & reqid, const QVariant & result = QVariant());
 
     protected:
         /// chains to base, connects sendRequest signal to _sendRequest slot

--- a/src/RPC.h
+++ b/src/RPC.h
@@ -404,6 +404,7 @@ namespace RPC {
         // Internally called by processObject()
         [[nodiscard]] ProcessObjectResult processObject_internal(QVariantMap &&);
         // Internally called by _sendResult and _sendError
+        // Precondition: Message must be either: isError() or isResponse() (this is not checked here for performance)
         [[nodiscard]] bool batchResponseFilter(const Message & msg);
         // Internally called to enqueue a new batch -- this may throw InvalidRequest if the QVariantList is empty
         void enqueueNewBatch(QVariantList &&);
@@ -457,6 +458,7 @@ namespace RPC {
         explicit BatchProcessor(ConnectionBase & parent, Batch && batch);
         ~BatchProcessor() override;
 
+        /// Precondition: Message must be either: isError() or isResponse() (this is not checked here for performance)
         bool acceptResponse(const Message &);
         void process() override;
 

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -706,8 +706,8 @@ void ServerBase::onPeerError(IdMixin::Id clientId, const QString &what)
         Debug() << "onPeerError, client " << clientId << " error: " << what.left(num);
     }
     if (Client *c = getClient(clientId); c) {
-        if (++c->info.errCt - c->info.nRequestsRcv >= kMaxErrorCount) {
-            Warning() << "Excessive errors (" << kMaxErrorCount << ") for: " << c->prettyName() << ", disconnecting";
+        if (const auto diff = ++c->info.errCt - c->info.nRequestsRcv; diff >= kMaxErrorCount) {
+            Warning() << "Excessive errors (" << diff << ") for: " << c->prettyName() << ", disconnecting";
             killClient(c);
             return;
         }

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -2653,6 +2653,7 @@ Client::Client(const RPC::MethodMap * mm, IdMixin::Id id_in, QTcpSocket *sock, i
     status = Connected ; // we are always connected at construction time.
     errorPolicy = ErrorPolicySendErrorMessage;
     setObjectName(QStringLiteral("Client.%1").arg(id_in));
+    setBatchPermitted(true); // TODO: make this come from config!
     on_connected();
     Log() << "New " << prettyName(false, false) << ", " << N << Util::Pluralize(QStringLiteral(" client"), N) << " total";
 }

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -2706,7 +2706,7 @@ bool Client::canAcceptBatch(RPC::BatchProcessor *batch)
         return false;
     }
     const uint64_t size = uint64_t(batch->getBatch().items.size());
-    const QString name = Debug::isEnabled() ? batch->objectName() : QString{};
+    const QString name = batch->objectName();
     const auto weakp = std::weak_ptr(perIPData);
     connect(batch, &QObject::destroyed, [size, weakp, name](QObject *){
         // this lambda runs in `batch`'s object context immediately

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -603,9 +603,11 @@ public:
         std::atomic_int64_t bdReqCtr{0}; ///< the number bitcoind requests active right now for all clients coming from this IP address.
         std::atomic_uint64_t bdReqCtr_cum{0}; ///< the number bitcoind requests, cumulatively, for all clients coming from this IP address.
         std::atomic_int64_t lastConnectionLimitReachedWarning{0}; ///< timstamp (in msec) of the last "connection limit exceeded" warning printed to the log for this IP address.
-        /// The number of batch requests that are currently active.
-        /// As RPC::BatchProcessors are created they increment this, and as they are deleted they decrement this.
+        /// The cumulative `batch.items.size()` for all batch requests currently active for this IP.
+        /// As RPC::BatchProcessors are created this is increased, and as they are deleted this is decreased.
         std::atomic_uint64_t nExtantBatchRequests{0};
+        /// The total estimated memory footprint of all extant batch requests for this IP
+        std::atomic_int64_t extantBatchRequestCosts{0};
     };
 
     std::shared_ptr<PerIPData> perIPData;

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -565,8 +565,8 @@ protected:
     /// Only Server instances can construct us
     friend class ::ServerBase;
     friend class ::Server;
-    /// NB: sock should be in an already connected state.
-    explicit Client(const RPC::MethodMap * methods, IdMixin::Id id, QTcpSocket *sock, int maxBuffer, unsigned maxBatch);
+    /// NB: sock should be in an already connected state. `options` should be guaranteed to outlive this instance.
+    explicit Client(const RPC::MethodMap * methods, IdMixin::Id id, QTcpSocket *sock, const Options &options);
 public:
     ~Client() override;
 
@@ -611,10 +611,6 @@ public:
     std::shared_ptr<PerIPData> perIPData;
 
     bool isSubscribedToHeaders = false;
-private:
-    const unsigned maxBatch : 24; // Nit: we use a 24-bit bitfield here to save space in this class.
-    static_assert (Options::maxBatchMax < 1U << 24); // ensure above bitfield can store max value
-public:
     std::atomic_int nShSubs{0};  ///< the number of unique scripthash subscriptions for this client.
 
     //bitcoind_throttle counter, per client
@@ -657,4 +653,6 @@ protected:
 
     /// Does some per-IP book-keeping. If everything checks out, returns true. Otherwise returns false.
     [[nodiscard]] bool canAcceptBatch(RPC::BatchProcessor *) override;
+private:
+    const Options & options;
 };

--- a/src/ThreadPool.h
+++ b/src/ThreadPool.h
@@ -127,7 +127,7 @@ private:
     std::atomic_int extant = 0, extantMaxSeen = 0;
     std::atomic_bool blockNewWork = false;
     /// maximum number of extant jobs we allow before failing and not enqueuing more.
-    std::atomic_int extantLimit = 10000;
+    std::atomic_int extantLimit = 15'000;
 };
 
 /// Semi-private class not intended to be constructed by client code, but used inside ThreadPool::SubmitWork.


### PR DESCRIPTION
Closes issue #73.

#### Summary of changes:

- Version bump to 1.6.0
- JSON-RPC "batch" request support is implemented, with some DoS controls baked in (default limit is batch size of 345 enforced as a total per-IP)
   -  New conf option `max_batch` (default `345`) is used to control the limit. Use `max_batch = 0` to disable JSON-RPC batching app-wide and return to previous Fulcrum behavior (pre-1.6.0 Fulcrum always had it disabled since it was unimplemented!). 
   - The batches also are throttled if they hit bitcoind hard (same mechanism used for individual non-batched requests).
   - The batches cannot exceed `max_buffer` in terms of request + reply size.
   - Individual batches cannot contain duplicate JSON-RPC `id`'s in their request objects. (An error is returned in the batch result for requests within a batch violating this invariant).
   - Multiple batches running in parallel for the same connection also must each contain requests with unique `id`'s. (Errors are returned for requests within a batch violating this invariant).
   - The request `id`'s within a batch may **not** be `null`. (Errors are returned for requests within a batch violating this).
   - If a client sends a batch request that does respect the unique `id`'s invariant, but then tries to violate that invariant by also sending individual non-batched requests at the same time that re-uses the same `id`'s seen in the batch, unspecified behavior may result (you may find things jumbled in terms of where each dupe `id`'s results ended up -- whether in a batch reply or outside of a batch reply).
- New defaults for some resource-related conf options:
  - `db_max_open_files` new default is `40` (was: `20`)
  - `db_mem` new default is `512` (was: `420`)
  -  `max_buffer` new default is `8000000` (was: `4000000`)
  - `max_subs_per_ip` new default is `75000` (was: `50000`)
  - `workqueue` new default is `15000` (was: `10000`)
- Block prefetcher (used when synching) now prefetches more blocks in the Bitcoin Core case (since their blocks are bounded to ~1.7 MB of data, so the prefetcher can get away with prefetching more blocks).
- Improved performance in the JSON-RPC message handling code to not do as many allocations and/or reduce copying (by leveraging `std::move` more in C++).

