### PR TITLE
Add new experimental option: `--fast-sync` + upgrade robin_hood to 3.11.15

### DIFF
--- a/doc/fulcrum-example-config.conf
+++ b/doc/fulcrum-example-config.conf
@@ -682,6 +682,25 @@ rpcpassword = hunter1
 # db_use_fsync = false
 
 
+# Fast sync = 'fast-sync' - DEFAULT: 0
+#
+# If specified, Fulcrum will use a UTXO Cache that consumes extra memory but
+# syncs up to to 2X faster. To use this feature, you must specify a memory value
+# in MB to allocate to the cache. It is recommended that you give this facility
+# at least 2000 MB for it to really pay off, although any amount of memory given
+# (minimum 200 MB) should be beneficial. Note that this feature is currently
+# experimental and the tradeoffs are: it is faster because it avoids redundant
+# disk I/O, however, this comes at the price of considerable memory consumption
+# as well as a sync that is less resilient to crashes mid-sync. If the process
+# is killed mid-sync, the database may become corrupt and lose UTXO data. Use
+# this feature only if you are 100% sure that won't happen during a sync.
+# Specify as much memory as you can, in MB, here, e.g.: 3000 to allocate 3000 MB
+# (3 GB). The default is off (0). This option only takes effect on initial sync,
+# otherwise this option has no effect.
+#
+#fast-sync = false
+
+
 # Maximum batch size (per IP) - 'max_batch' - DEFAULT: 345
 #
 # The maximum size of JSON-RPC batch requests to the server. Set this to 0

--- a/doc/unix-man-page.md
+++ b/doc/unix-man-page.md
@@ -118,6 +118,9 @@ Once the server finishes synching it will behave like an ElectronX/ElectrumX ser
 --compact-dbs
 :   If specified, Fulcrum will compact all databases on startup. The compaction process reduces database disk space usage by removing redundant/unused data. Note that rocksdb normally compacts the databases in the background while Fulcrum is running, so using this option to explicitly compact the database files on startup is not strictly necessary.
 
+--experimental-fast-sync
+:   If specified, Fulcrum will use an experimental new feature that consumes extra memory but syncs up to to 2X faster. To use this feature, you must specify a memory value in MB to allocate to this facility. You should give this facility at least 2 GB for it to really pay off. Note that this feature is currently experimental and the tradeoffs are: it is faster because it avoids redundant disk I/O, however, this comes at the price of considerable memory consumption as well as a sync that is less resilient to crashes mid-sync. If the process is killed mid-sync, the database may become corrupt and lose UTXO data. Use this feature only if you are 100% sure that won't happen during a sync. Specify as much memory as you can, in MB, here, e.g.: 3000 to allocate 3000 MB (3 GB). The default is off (0). This option only takes effect on initial sync, otherwise this option has no effect.
+
 --dump-sh <outputfile>
 :    *This is an advanced debugging option*. Dump script hashes. If specified, after the database is loaded, all of the script hashes in the database will be written to outputfile as a JSON array.
 

--- a/doc/unix-man-page.md
+++ b/doc/unix-man-page.md
@@ -1,6 +1,6 @@
 % FULCRUM(1) Version 1.6.0 | Fulcrum Manual
 % Fulcrum is written by Calin Culianu (cculianu)
-% January 21, 2022
+% January 24, 2022
 
 # NAME
 
@@ -118,8 +118,8 @@ Once the server finishes synching it will behave like an ElectronX/ElectrumX ser
 --compact-dbs
 :   If specified, Fulcrum will compact all databases on startup. The compaction process reduces database disk space usage by removing redundant/unused data. Note that rocksdb normally compacts the databases in the background while Fulcrum is running, so using this option to explicitly compact the database files on startup is not strictly necessary.
 
---experimental-fast-sync
-:   If specified, Fulcrum will use an experimental new feature that consumes extra memory but syncs up to to 2X faster. To use this feature, you must specify a memory value in MB to allocate to this facility. You should give this facility at least 2 GB for it to really pay off. Note that this feature is currently experimental and the tradeoffs are: it is faster because it avoids redundant disk I/O, however, this comes at the price of considerable memory consumption as well as a sync that is less resilient to crashes mid-sync. If the process is killed mid-sync, the database may become corrupt and lose UTXO data. Use this feature only if you are 100% sure that won't happen during a sync. Specify as much memory as you can, in MB, here, e.g.: 3000 to allocate 3000 MB (3 GB). The default is off (0). This option only takes effect on initial sync, otherwise this option has no effect.
+--fast-sync
+:   If specified, Fulcrum will use a UTXO Cache that consumes extra memory but syncs up to to 2X faster. To use this feature, you must specify a memory value in MB to allocate to the cache. It is recommended that you give this facility at least 2000 MB for it to really pay off, although any amount of memory given (minimum 200 MB) should be beneficial. Note that this feature is currently experimental and the tradeoffs are: it is faster because it avoids redundant disk I/O, however, this comes at the price of considerable memory consumption as well as a sync that is less resilient to crashes mid-sync. If the process is killed mid-sync, the database may become corrupt and lose UTXO data. Use this feature only if you are 100% sure that won't happen during a sync. Specify as much memory as you can, in MB, here, e.g.: 3000 to allocate 3000 MB (3 GB). The default is off (0). This option only takes effect on initial sync, otherwise this option has no effect.
 
 --dump-sh <outputfile>
 :    *This is an advanced debugging option*. Dump script hashes. If specified, after the database is loaded, all of the script hashes in the database will be written to outputfile as a JSON array.

--- a/doc/unix-man-page.md
+++ b/doc/unix-man-page.md
@@ -1,10 +1,10 @@
 % FULCRUM(1) Version 1.6.0 | Fulcrum Manual
 % Fulcrum is written by Calin Culianu (cculianu)
-% January 17, 2022
+% January 21, 2022
 
 # NAME
 
-**fulcrum** - SPV server for Bitcoin Cash and Bitcoin BTC.
+**fulcrum** - A Bitcoin Cash (and Bitcoin BTC) Blockchain SPV Server
 
 # SYNOPSIS
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -1265,8 +1265,8 @@ void App::parseArgs()
     }
 
     // TESTING utxocache
-    if (const auto memfree = Util::getAvailablePhysicalRAM(); memfree > options->utxocache && (memfree * 3ull / 4ull) <= std::numeric_limits<size_t>::max()) {
-        options->utxocache = static_cast<size_t>(memfree * 3ull / 4ull); // take 3/4 of what system reported as memfree
+    if (const auto memfree = Util::getAvailablePhysicalRAM(); memfree > options->utxocache && (memfree / 2ull) <= std::numeric_limits<size_t>::max()) {
+        options->utxocache = static_cast<size_t>(memfree / 2ull); // take 1/2 of what system reported as memfree (we need extra to commit to DB)
         Util::AsyncOnObject(this, [memfree, u=options->utxocache]{
             DebugM("utxo cache size set to: ", u, " (available physical ram: ", memfree, ")");
         });

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -495,14 +495,14 @@ void App::parseArgs()
     {
        "experimental-fast-sync",
        QString("If specified, " APPNAME " will use an experimental new feature that consumes extra memory but syncs up"
-               " to 40% faster. To use this feature, you must specify a memory value in MB to allocate to this"
+               " to to 2X faster. To use this feature, you must specify a memory value in MB to allocate to this"
                " facility. You should give this facility at least 2 GB for it to really pay off. Note that this feature"
                " is currently experimental and the tradeoffs are: it is faster because it avoids redundant disk I/O,"
                " however, this comes at the price of considerable memory consumption as well as a sync that is less"
                " resilient to crashes mid-sync. If the process is killed mid-sync, the database may become corrupt"
                " and lose UTXO data. Use this feature only if you are 100% sure that won't happen during a sync."
                " Specify as much memory as you can, in MB, here, e.g.: 3000 to allocate 3000 MB (3 GB). The default is"
-               " off (0). This option only takes effect on initial sync, otherwise this option does nothing.\n"),
+               " off (0). This option only takes effect on initial sync, otherwise this option has no effect.\n"),
        QString("MB"),
     },
     {

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -41,6 +41,7 @@
 #include <QSslSocket>
 #include <QTextStream>
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <clocale>
@@ -1285,7 +1286,7 @@ void App::parseArgs()
         if (!ok || val < 0.)
             throw BadArgs(QString("experimental-fast-sync: Slease specify a positive numeric value in MB, or 0 to disable"));
         const uint64_t bytes = static_cast<uint64_t>(val * 1e6);
-        if (uint64_t memfree; bytes > (memfree = std::numeric_limits<size_t>::max()) || bytes > (memfree = Util::getAvailablePhysicalRAM()))
+        if (uint64_t memfree; bytes > (memfree = std::min<uint64_t>(Util::getAvailablePhysicalRAM(), std::numeric_limits<size_t>::max())))
             throw BadArgs(QString("experimental-fast-sync: Specified value (%1 bytes) is too large to fit in available"
                                   " system memory (limit is: %2 bytes)").arg(bytes).arg(qulonglong(memfree)));
         else if (bytes > 0 && bytes < Options::minUtxoCache)

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -309,7 +309,7 @@ void App::cleanup_WaitForThreadPoolWorkers()
 void App::parseArgs()
 {
     QCommandLineParser parser;
-    parser.setApplicationDescription("A Bitcoin Cash Blockchain SPV Server.");
+    parser.setApplicationDescription("A Bitcoin Cash (and Bitcoin BTC) Blockchain SPV Server");
     parser.addHelpOption();
 
     static constexpr auto RPCUSER = "RPCUSER", RPCPASSWORD = "RPCPASSWORD"; // optional env vars we use below

--- a/src/CoTask.cpp
+++ b/src/CoTask.cpp
@@ -21,9 +21,10 @@
 
 #include <QThread>
 
-CoTask::CoTask(const QString &name)
+CoTask::CoTask(const QString &name_)
+    : name{name_}
 {
-    thr = std::thread([this, name] {
+    thr = std::thread([this] {
         if (QThread *qthr; !name.isEmpty() && (qthr = QThread::currentThread()))
             qthr->setObjectName(name);
         thrFunc();

--- a/src/CoTask.h
+++ b/src/CoTask.h
@@ -35,6 +35,8 @@
 class CoTask
 {
 public:
+    const QString name;
+
     CoTask(const QString &name = {});
     ~CoTask();
 

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -1076,7 +1076,7 @@ struct Controller::StateMachine
     /// will be valid and not empty only if a zmq hashblock notification happened while we were running the block & mempool synch task
     QByteArray mostRecentZmqNotif;
 
-    /// TODO: Add description HERE
+    /// This is valid only if we are in an initial sync
     std::optional<Storage::InitialSyncRAII> initialSyncRaii;
 };
 
@@ -1278,7 +1278,10 @@ void Controller::process(bool beSilentIfUpToDate)
                     sm->suppressSaveUndo = sm->nHeaders > 0 && sm->ht > 0 && sm->nHeaders >= sm->ht
                                            && unsigned(sm->nHeaders - sm->ht) > storage->configuredUndoDepth();
                 }
-                // TESTING TODO FIXME ADD COMMENTS HERE OR PUT THIS IN A DIFFERENT PLACE?!
+
+                // Set initial sync flag, if we are in initial sync (heuristic is: initial sync == we have no undo data)
+                // Note: This may not be the best place for this. Also, if assumptions change, this will not
+                // work as before. TODO: revisit the placement of where this logic goes.
                 if (!hasUndo && !sm->initialSyncRaii)
                     sm->initialSyncRaii.emplace( storage->setInitialSync() );
                 else if (sm->initialSyncRaii && hasUndo)

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -1043,7 +1043,7 @@ struct Controller::StateMachine
     int nHeaders = -1; ///< the number of headers our bitcoind has, in the chain we are synching
     BTC::Net net = BTC::Net::Invalid;  ///< This gets set by calls to getblockchaininfo by parsing the "chain" in the resulting dict
 
-    robin_hood::unordered_flat_map<unsigned, PreProcessedBlockPtr> ppBlocks; // mapping of height -> PreProcessedBlock (we use an unordered_flat_map because it's faster for frequent updates)
+    robin_hood::unordered_map<unsigned, PreProcessedBlockPtr> ppBlocks; // mapping of height -> PreProcessedBlock (we use robin_hood because it's faster for frequent updates)
     unsigned startheight = 0, ///< the height we started at
              endHeight = 0; ///< the final (inclusive) block height we expect to receive to pronounce the synch done
 

--- a/src/Options.h
+++ b/src/Options.h
@@ -270,6 +270,9 @@ public:
                               maxBatchMax = 100'000; ///< This 100k limit is ridiculous, but we will allow it.
     static constexpr bool isMaxBatchInRange(unsigned n) { return n >= maxBatchMin && n <= maxBatchMax; }
     unsigned maxBatch = defaultMaxBatch;
+
+    // TESTING: utxocache
+    size_t utxocache = 512 * 1024 * 1024;
 };
 
 /// A class encapsulating a simple read-only config file format.  The format is similar to the bitcoin.conf format

--- a/src/Options.h
+++ b/src/Options.h
@@ -271,8 +271,9 @@ public:
     static constexpr bool isMaxBatchInRange(unsigned n) { return n >= maxBatchMin && n <= maxBatchMax; }
     unsigned maxBatch = defaultMaxBatch;
 
-    // TESTING: utxocache
-    size_t utxocache = 512 * 1024 * 1024;
+    // CLI: --experimental-fast-sync (experimental)
+    static constexpr size_t defaultUtxoCache = 0, minUtxoCache = 512ull * 1000ull * 1000ull; // 0 is off, otherwise 512 MB min
+    size_t utxoCache = defaultUtxoCache;
 };
 
 /// A class encapsulating a simple read-only config file format.  The format is similar to the bitcoin.conf format

--- a/src/Options.h
+++ b/src/Options.h
@@ -271,8 +271,8 @@ public:
     static constexpr bool isMaxBatchInRange(unsigned n) { return n >= maxBatchMin && n <= maxBatchMax; }
     unsigned maxBatch = defaultMaxBatch;
 
-    // CLI: --experimental-fast-sync (experimental)
-    static constexpr size_t defaultUtxoCache = 0, minUtxoCache = 512ull * 1000ull * 1000ull; // 0 is off, otherwise 512 MB min
+    // CLI: --fast-sync (experimental)
+    static constexpr size_t defaultUtxoCache = 0, minUtxoCache = 200ull * 1000ull * 1000ull; // 0 is off, otherwise 200 MB min
     size_t utxoCache = defaultUtxoCache;
 };
 

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -2362,7 +2362,7 @@ void Storage::UTXOBatch::remove(const TXO &txo, const HashX &hashX, const Compac
         static const QString errMsgPrefix("Failed to issue a batch delete for a utxo");
         GenericBatchDelete(p->utxosetBatch, txo, errMsgPrefix);
     } else {
-        p->cache->remove(txo, false /* TODO: optimize this to sometimes pass true here??? */);
+        p->cache->remove(txo, /* Hack ---> */ p->cache->cacheMisses == 0 ? true : false);
     }
     {
         // enqueue delete from scripthash_unspent db

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1131,7 +1131,7 @@ class Storage::UTXOCache
                 utxos.erase(tit);
                 ordering.erase(oit);
                 const auto & [tit2, inserted2] = utxos.try_emplace(txo, it);
-                if (UNLIKELY(!inserted2)) throw InternalError("Tried overwriting existing TXO in cache but faile! THIS SHOULD NEVER HAPPEN!");
+                if (UNLIKELY(!inserted2)) /* paranoia */ throw InternalError("Tried overwriting existing TXO in cache but failed! THIS SHOULD NEVER HAPPEN!");
                 ret = false;
             }
         }

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -53,7 +53,6 @@
 #include <cstdlib>
 #include <cstring> // for memcpy
 #include <functional>
-#include <future>
 #include <limits>
 #include <list>
 #include <map>

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1312,12 +1312,12 @@ public:
         do_flush();
     }
 
-    void reserve(size_t n) {
-        utxos.reserve(n);
-        adds.reserve(n);
-        rms.reserve(n);
-        shunspentAdds.reserve(n);
-        shunspentRms.reserve(n);
+    void reserve(size_t hashMaps, size_t vectors) {
+        utxos.reserve(hashMaps);
+        adds.reserve(hashMaps);
+        rms.reserve(vectors);
+        shunspentAdds.reserve(hashMaps);
+        shunspentRms.reserve(vectors);
     }
     void shrink_to_fit() {
         utxos.rehash(0);
@@ -2528,7 +2528,8 @@ void Storage::setInitialSync(bool b) {
             p->db.utxoCache.reset(new UTXOCache("Storage UTXO Cache", p->db.utxoset, p->db.shunspent, p->db.defReadOpts, p->db.defWriteOpts));
             // Reserve about 10 million entries per GB of utxoCache memory given to us
             // We need to do this, despite the extra memory bloat, because it turns out rehashing is very painful.
-            p->db.utxoCache->reserve( options->utxoCache / size_t(100u) );
+            p->db.utxoCache->reserve( options->utxoCache / size_t(100u) /* hashmaps = 10 mln per GB */,
+                                      8192 /* vectors = fixed reserve */ );
         } else {
             Log() << "experimental-fast-sync: Not enabled";
         }

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -4336,10 +4336,8 @@ namespace {
         using CtrType = decltype(DeduceSmallestTypeForNumBytes<NB <= 2 ? (NB == 1 ? 4 : 2) : 1>());
         const auto nrec = rf->numRecords();
         Log() << "Records: " << nrec;
-        //std::unordered_map<KeyType, CtrType> cols;
         robin_hood::unordered_flat_map<KeyType, CtrType> cols;
         Log() << "Reserving table ...";
-        //std::vector<CtrType> cols(std::numeric_limits<KeyType>::max(), CtrType{0});
         size_t nCols = 0, maxCol = 0;
         KeyType maxColVal = 0;
         cols.reserve(std::min<size_t>(nrec, std::numeric_limits<KeyType>::max()));

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1667,7 +1667,7 @@ void Storage::compactAllDBs()
 
 void Storage::gentlyCloseAllDBs()
 {
-    if (p->db.utxoCache) p->db.utxoCache.reset(); // implicitly flushes to DB...
+    p->db.utxoCache.reset(); // if was valid, implicitly flushes UTXO Cache pending writes to DB...
 
     // do FlushWAL() and Close() to gently close the dbs
     for (auto & [db] : p->db.openDBs) {

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1356,8 +1356,8 @@ class Storage::UTXOCache
             // Already there! Paranoia check here ... it turns out even in pre-BIP34 txns, this cannot happen
             // because we uniquely identify txns by unique id number, so dupe tx-hash's (as was possible pre-BIP34)
             // cannot trigger this branch.  This branch is here strictly for paranoia.
-            DebugM(__func__, ": WARNING dupe txo encountered with key: \"", it->first.toHex(), "\" [amt1: ", it->second,
-                   " amt2: ", amt, "], overwriting existing with amt2.");
+            Warning() << __func__ << ": WARNING dupe txo encountered with key: \"" << it->first.toHex() << "\" [amt1: "
+                      << it->second << " amt2: " << amt << "], overwriting existing with amt2.";
             it->second = amt; // overwrite existing to preserve behavior of pre-UTXOCache code.
         }
         // NOTE: Assumption is that an add will never add a shunspent key that is in the shunspentRms vector.

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1142,7 +1142,6 @@ class Storage::UTXOCache
             /* As a performance optimization we removed the below check because on any extant chain
              * even pre-BIP34, this branch is not taken, ever.*/
             if (const auto rit = rms.find(txo); UNLIKELY(rit != rms.end())) {
-                // Is this a wasteful call? We use debug code here to determine it it was.
                 DebugM(__func__, ": WARNING added txo ", txo.toString(), ", but already was in rms set (will remove from rms set)");
                 rms.erase(rit);
             }

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1296,11 +1296,7 @@ public:
         DebugM(name, ": created");
         // Tune this? (so far 33 million doesn't eat that much RAM in practice so it's ok.. we want to avoid rehashing)
         constexpr size_t rsv = 1ul << 25; // ~33 million
-        utxos.reserve(rsv);
-        adds.reserve(rsv);
-        rms.reserve(rsv);
-        shunspentAdds.reserve(rsv);
-        shunspentRms.reserve(rsv);
+        reserve(rsv);
     }
 
     ~UTXOCache() {

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -2789,7 +2789,7 @@ void Storage::addBlock(PreProcessedBlockPtr ppb, bool saveUndo, unsigned nReserv
             }
 
             // TODO FIXME HAVE THIS COME FROM CONFIG?
-            constexpr size_t UTXO_MEM_LIMIT = 4ULL * 1000ULL * 1000ULL * 1000ULL;
+            const size_t UTXO_MEM_LIMIT = options->utxocache;
             if (p->db.utxoCache && p->db.utxoCache->memUsage() > UTXO_MEM_LIMIT)
                 p->db.utxoCache->limitSize(UTXO_MEM_LIMIT * 3 / 4 /* chop down to 3/4 size */);
 

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -993,7 +993,7 @@ struct Storage::Pvt
 
         std::unique_ptr<TxHash2TxNumMgr> txhash2txnumMgr; ///< provides a bit of a higher-level interface into the db
 
-        /// One of these is alive if we are in an initial sync and user specified --experimental-fast-sync
+        /// One of these is alive if we are in an initial sync and user specified --fast-sync
         /// It caches UTXOs in memory and delays UTXO writes to DB so we don't have to do so much back-and-forth to
         /// rocksdb.
         std::unique_ptr<UTXOCache> utxoCache;
@@ -2699,14 +2699,14 @@ void Storage::setInitialSync(bool b) {
     assert(bool(p->db.utxoset) && bool(p->db.shunspent));
     if (b && !p->db.utxoCache) {
         if (options->utxoCache > 0) {
-            Log() << "experimental-fast-sync: Enabled; UTXO cache size set to " << options->utxoCache
+            Log() << "fast-sync: Enabled; UTXO cache size set to " << options->utxoCache
                   << " bytes (available physical RAM: " << Util::getAvailablePhysicalRAM() << " bytes)";
             p->db.utxoCache.reset(new UTXOCache("Storage UTXO Cache", p->db.utxoset, p->db.shunspent, p->db.defReadOpts, p->db.defWriteOpts));
             // Reserve about 3.6 million entries per GB of utxoCache memory given to us
             // We need to do this, despite the extra memory bloat, because it turns out rehashing is very painful.
             p->db.utxoCache->autoReserve(options->utxoCache);
         } else {
-            Log() << "experimental-fast-sync: Not enabled";
+            Log() << "fast-sync: Not enabled";
         }
     } else if (!b && p->db.utxoCache) {
         Log() << "Initial sync ended, flushing and deleting UTXO Cache ...";

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1176,7 +1176,7 @@ class Storage::UTXOCache
             batch.Clear();
             if (t.msec<int>() >= 200) {
                 const auto ct = batchCount;
-                DebugM("do_flush: batch write of ", ct, " ", DBName(db), Util::Pluralize(" item", ct), " took ", t.msecStr(), " msec");
+                DebugM("batch write of ", ct, " ", DBName(db), Util::Pluralize(" item", ct), " took ", t.msecStr(), " msec");
             }
             batchCount = 0;
         };

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1034,19 +1034,19 @@ class Storage::UTXOCache
         return ret;
     }
 
-    bool rm(const TXO &txo, bool addToRmSet) {
+    bool rm(const TXO &txo) {
         bool ret = false;
-        //bool wasInAdds = false;
+        bool wasInAdds = false;
         if (auto it = utxos.find(&txo); it != utxos.end()) {
             if (auto ait = adds.find(it); ait != adds.end()) {
-                //wasInAdds = true;
+                wasInAdds = true;
                 adds.erase(ait);
             }
             ordering.erase(it->second);
             utxos.erase(it);
             ret = true;
         }
-        if (addToRmSet /*&& !wasInAdds*/) rms.insert(txo);
+        if (!wasInAdds) rms.insert(txo);
         return ret;
     }
 
@@ -1185,7 +1185,7 @@ public:
         return ret;
     }
 
-    bool remove(const TXO & txo, bool isNotInDb) { return rm(txo, !isNotInDb); }
+    bool remove(const TXO & txo) { return rm(txo); }
 
     bool put(const TXO & txo, const TXOInfo & info, bool isNotInDb) { return add({txo, info}, isNotInDb); }
 
@@ -2362,7 +2362,7 @@ void Storage::UTXOBatch::remove(const TXO &txo, const HashX &hashX, const Compac
         static const QString errMsgPrefix("Failed to issue a batch delete for a utxo");
         GenericBatchDelete(p->utxosetBatch, txo, errMsgPrefix);
     } else {
-        p->cache->remove(txo, /* Hack ---> */ p->cache->cacheMisses == 0 ? true : false);
+        p->cache->remove(txo);
     }
     {
         // enqueue delete from scripthash_unspent db

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1005,7 +1005,7 @@ class Storage::UTXOCache
 
     void do_flush() {
         if (const auto ct = adds.size() + rms.size() + shunspentAdds.size() + shunspentRms.size(); ct) {
-            Log() << name <<  ": Flushing " << ct << Util::Pluralize(" item", ct) << " to UTXO & ScriptHashUnspent dbs ...";
+            Log() << name <<  ": Flushing " << ct << Util::Pluralize(" item", ct) << " to UTXO & ScriptHashUnspent DBs ...";
         } else {
             // nothing to do!
             return;

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1189,6 +1189,7 @@ class Storage::UTXOCache
         if (!adds.empty() || !rms.empty())
             t1 = std::thread([&]{
                 try {
+                    if (auto *t = QThread::currentThread()) t->setObjectName(this->name + " - Writer.1"); // for logger
                     static const QString errMsgBatchWrite("Error issuing batch write to utxoset db for a utxo update");
                     if (!db) throw InternalError("utxoset db is nullptr! FIXME!");
                     size_t batchCount = 0;
@@ -1233,6 +1234,7 @@ class Storage::UTXOCache
         if (!shunspentAdds.empty() || !shunspentRms.empty())
             t2 = std::thread([&]{
                 try {
+                    if (auto *t = QThread::currentThread()) t->setObjectName(this->name + " - Writer.2"); // for logger
                     static const QString errMsgBatchWrite("Error issuing batch write to scripthash_unspent db for a shunspent update");
                     if (!shunspentdb) throw InternalError("scripthash_unspent db is nullptr! FIXME!");
                     size_t batchCount = 0;

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -2555,10 +2555,10 @@ void Storage::setInitialSync(bool b) {
             Log() << "experimental-fast-sync: Enabled; UTXO cache size set to " << options->utxoCache
                   << " bytes (available physical RAM: " << Util::getAvailablePhysicalRAM() << " bytes)";
             p->db.utxoCache.reset(new UTXOCache("Storage UTXO Cache", p->db.utxoset, p->db.shunspent, p->db.defReadOpts, p->db.defWriteOpts));
-            // Reserve about 10 million entries per GB of utxoCache memory given to us
+            // Reserve about 1 million entries per GB of utxoCache memory given to us
             // We need to do this, despite the extra memory bloat, because it turns out rehashing is very painful.
-            p->db.utxoCache->reserve( options->utxoCache / size_t(100u) /* hashmaps = 10 mln per GB */,
-                                      8192 /* vectors = fixed reserve */ );
+            p->db.utxoCache->reserve( options->utxoCache / size_t(1000u) /* hashmaps = 1 mln per GB */,
+                                      1u << 15 /* vectors = fixed reserve of 32k */ );
         } else {
             Log() << "experimental-fast-sync: Not enabled";
         }

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1442,6 +1442,7 @@ class Storage::UTXOCache
                     if (!inum) { /* coinbase, skip */ }
                     else if (in.parentTxOutIdx.has_value()) { /* spent in this block, skip */ }
                     else if (TXO t{in.prevoutHash, in.prevoutN}; !contains(t)) {
+                        ++cacheMisses;
                         const unsigned index = keys.size();
                         const TXO & txo = index2TXO.try_emplace(index, std::move(t)).first->second;
                         keyData.push_back(Serialize(txo));
@@ -1449,7 +1450,8 @@ class Storage::UTXOCache
                         keys.emplace_back(ser.constData(), size_t(ser.size()));
                         values.emplace_back();
                         statuses.emplace_back();
-                    }
+                    } else
+                        ++cacheHits;
                     ++inum;
                 }
             }

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -313,6 +313,7 @@ public:
     /// optionally indented by `indent*indentLevel` spaces.  If indent is 0, the output will all be on 1 line with no padding.
     size_t dumpAllScriptHashes(QIODevice *outDev, unsigned indent=0, unsigned indentLevel=0, const DumpProgressFunc & = {}, size_t progInterval = 100000) const;
 
+    /// Leverage RAII to have this class auto-notified when initial sync has ended.
     class InitialSyncRAII {
         QPointer<Storage> storage;
         static inline std::atomic_int instanceCtr{0};
@@ -329,6 +330,8 @@ public:
         InitialSyncRAII &operator=(InitialSyncRAII && o) { return this->operator=(std::as_const(o)); }
     };
 
+    /// Called by Controller, if it thinks it's in an intitial sync. Controller hangs on to the return value until
+    /// initial sync has ended.
     [[nodiscard]] InitialSyncRAII setInitialSync() { return InitialSyncRAII{*this}; }
 
 protected:
@@ -388,7 +391,7 @@ protected:
     /// Reads the UtxoCt from the meta db. If they key is missing it will return 0.  May throw on low-level db error.
     int64_t readUtxoCtFromDB() const;
 
-    /// TODO: DESCRIPTION HERE
+    /// Internally called to create or destroy the UTXO Cache, if --experimental-fast-sync is enabled
     void setInitialSync(bool);
     friend class InitialSyncRAII;
 

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -292,12 +292,13 @@ public:
 
     // -- Tx Hash index based methods
     using TxHeightsResult = std::vector<std::optional<BlockHeight>>;
+
     /// Thread-safe. Does take mempool, blkInfo, and blocksLock locks in shared mode. Returns an array whose length is
-    /// equal to txHashes.size(), and for each element: if the optional is valid, then BlockHeight=0 means mempool,
-    /// and >0 means a confirmed height. If a particular TxHash was not found in the mempool or blockchain, that element
+    /// equal to txHashes.size(), and for each element: if the optional is valid, then BlockHeight=0 means mempool, and
+    /// >0 means a confirmed height. If a particular TxHash was not found in the mempool or blockchain, that element
     /// will have a std::nullopt.
     ///
-    /// May throw DatabaseError (unlikely) or some other Exception subclass.  Note that txHashes should contain 0 or
+    /// May throw DatabaseError (unlikely) or some other Exception subclass. Note that txHashes should contain 0 or
     /// more 32-byte hashes in big-endian (JSON) memory order, otherwise this may throw if the hashes are of the wrong
     /// length.
     TxHeightsResult getTxHeights(const std::vector<TxHash> &txHashes) const;
@@ -307,13 +308,13 @@ public:
     // --- DUMP methods --- (used for debugging, largely)
 
     using DumpProgressFunc = std::function<void(size_t)>;
-    /// Thread-safe.  Call this from any thread, but ideally call it from a threadPool worker thread, since it may
-    /// take a while.
-    /// Dumps all scripthashes as JSON data to output device outDev as an array of hex-encoded JSON strings,
-    /// optionally indented by `indent*indentLevel` spaces.  If indent is 0, the output will all be on 1 line with no padding.
+    /// Thread-safe. Call this from any thread, but ideally call it from a threadPool worker thread, since it may take
+    /// a while. Dumps all scripthashes as JSON data to output device outDev as an array of hex-encoded JSON strings,
+    /// optionally indented by `indent*indentLevel` spaces. If indent is 0, the output will all be on 1 line with no
+    /// padding.
     size_t dumpAllScriptHashes(QIODevice *outDev, unsigned indent=0, unsigned indentLevel=0, const DumpProgressFunc & = {}, size_t progInterval = 100000) const;
 
-    /// Leverage RAII to have this class auto-notified when initial sync has ended.
+    /// Leverages RAII to have the Storage class auto-notified when initial sync has started & ended.
     class InitialSyncRAII {
         QPointer<Storage> storage;
         static inline std::atomic_int instanceCtr{0};
@@ -330,8 +331,16 @@ public:
         InitialSyncRAII &operator=(InitialSyncRAII && o) { return this->operator=(std::as_const(o)); }
     };
 
-    /// Called by Controller, if it thinks it's in an intitial sync. Controller hangs on to the return value until
-    /// initial sync has ended.
+    /// Called by Controller, if it thinks it's in an intitial sync. Controller keeps an instance of the returned value
+    /// until initial sync has ended. (In other words, callers are expected to end the lifetime of the returned value
+    /// when they wish to assert that "InitialSync" has ended).
+    ///
+    /// Note: If multiple threads in the application attempt to manage the high-level concept of "InitialSync" at the
+    /// same time, there may be race conditions as to whether "InitialSync" is really actually still asserted after
+    /// this call has returned, or whether it really is false after the lifetime of the returned `InitialSyncRAII`
+    /// value has ended. This is because execution may be interleaved in any order, including ones in which another
+    /// thread may swoop in and change things around from underneath out feet. Long story short: this is a quick and
+    /// lightweight mechanism intended to be used and "owned" by the Controller object *only*.
     [[nodiscard]] InitialSyncRAII setInitialSync() { return InitialSyncRAII{*this}; }
 
 protected:

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -400,7 +400,7 @@ protected:
     /// Reads the UtxoCt from the meta db. If they key is missing it will return 0.  May throw on low-level db error.
     int64_t readUtxoCtFromDB() const;
 
-    /// Internally called to create or destroy the UTXO Cache, if --experimental-fast-sync is enabled
+    /// Internally called to create or destroy the UTXO Cache, if --fast-sync is enabled
     void setInitialSync(bool);
     friend class InitialSyncRAII;
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -349,7 +349,7 @@ namespace Util {
 
     uint64_t getAvailablePhysicalRAM()
     {
-        uint64_t ret = 512u * 1024u * 1024u; // just return 512MB, even if it's wrong, for unknown platforms
+        uint64_t ret = 2048u * 1024u * 1024u; // just return 2GB, even if it's wrong, for unknown platforms
 #if defined(Q_OS_WINDOWS)
         MEMORYSTATUSEX statex;
         statex.dwLength = sizeof(statex);

--- a/src/Util.h
+++ b/src/Util.h
@@ -803,6 +803,9 @@ namespace Util {
 
     struct MemUsage { std::size_t phys{}, virt{}; };
     MemUsage getProcessMemoryUsage();
+    /// On Linux and Windows, this will be accurate. On OSX will just be 1/2 of physical RAM.
+    /// If unknown platform, or as a fallback on error, will return 512MiB.
+    uint64_t getAvailablePhysicalRAM();
 
     /// A namespace for a bunch of functionality that can be used from an async POSIX signal handler.
     ///

--- a/src/Util.h
+++ b/src/Util.h
@@ -804,7 +804,7 @@ namespace Util {
     struct MemUsage { std::size_t phys{}, virt{}; };
     MemUsage getProcessMemoryUsage();
     /// On Linux and Windows, this will be accurate. On OSX will just be 1/2 of physical RAM.
-    /// If unknown platform, or as a fallback on error, will return 512MiB.
+    /// If unknown platform, or as a fallback on error, will return 2GiB.
     uint64_t getAvailablePhysicalRAM();
 
     /// A namespace for a bunch of functionality that can be used from an async POSIX signal handler.


### PR DESCRIPTION
This new option (default disabled) only takes effect on initial sync.  The option can be specified either via CLI as `--fast-sync <MB>` or in the conf file as `fast-sync = <MB>`.  Where `<MB>` is a value in megabytes (minimum: 200, maximum: machine available physical RAM).  When enabled, and on initial sync only, a UTXO Cache will be created to store both `TXO`/`TXOInfo` pairs and `scripthash_unspent` DB adds/deletes.  

Use of this cache during sync avoids excessive calls into rocksdb for reading and writing.  Moreover, the way the blockchain data works is UTXOs are often created temporarily only to be deleted a few blocks later.  Without this cache, each such creation/deletion in the lifecycle of a UTXO would involve a write -> read -> delete cycle for the UTXO's lifetime. This is a lot of back-and-forth to the DB in an already hot code path (`Storage::addBlock`).

So, with this `--fast-sync` option enabled, the user can opt to sacrifice memory but gain speed.  This option should particularly be useful for users syncing on machines using HDDs but with lots of memory to spare.

In my testing, a full BTC sync was just under 2X faster when giving Fulcrum `--fast-sync 6000` than it was without this option.  However, memory load peaked at over 8GB. YMMV -- there are no guarantees as to how much faster it will be, but in principle it should always be a win to use this option (from the perspective of initial sync time).

One additional caveat to this facility: It is less resilient to crashes.  Since we aren't committing UTXO data to the DB with each block, a crash now is guaranteed to lead to a state of database corruption and/or inconsistency. (Note: if the app exits gracefullty via `Ctrl-C` and/or `SIGINT`, then DB will be consistent, as it always was even before this option).

During initial sync, this fragility to crashes likely won't be a problem anyway since the admin is very much paying attention to the state of the app as it's running during sync, and likely will notice a crash (and subsequent error on restart of the app, when it detects a bad DB state).  Probably an admin with decent amounts of memory to devote to the sync would prefer for the sync to complete faster, than for it to be slower but more "resilient".

The option is off by default and so if not used the code path for synching remains the same.