### PR TITLE
Fix typo in fulcrum-example-config.conf

### DIFF
--- a/doc/fulcrum-example-config.conf
+++ b/doc/fulcrum-example-config.conf
@@ -170,7 +170,7 @@ rpcpassword = hunter1
 
 # SSL certificate - 'cert' - DEFAULT: None (required for SSL)
 #
-# Specifes the SSL certificate to use for all SSL ports. The certificate must be
+# Specifies the SSL certificate to use for all SSL ports. The certificate must be
 # in PEM format. If using self-signed certs, the .pem file should contain a
 # single certificate. If using CA-signed certs, the .pem file should contain the
 # full certificate chain (e.g. fullchain.pem).
@@ -303,7 +303,7 @@ rpcpassword = hunter1
 #
 # The "banner" text file to send to clients when they request the server banner.
 # Specify a file path to a server-readable UTF-8 encoded text file (maximum file
-# lemgth: 16384 bytes). Typically Electron Cash clients ask for the server
+# length: 16384 bytes). Typically Electron Cash clients ask for the server
 # banner (via the "server.banner" RPC method) when they first connect to your
 # server. They then display this text in the "Console" tab of the Electron Cash
 # GUI. Some server admins get creative with this file and include ASCII or emoji
@@ -332,7 +332,7 @@ rpcpassword = hunter1
 
 
 #-------------------------------------------------------------------------------
-# PEER DISCOCERY AND PUBLIC SERVER OPTIONS
+# PEER DISCOVERY AND PUBLIC SERVER OPTIONS
 #-------------------------------------------------------------------------------
 
 # Public hostname - 'hostname' - DEFAULT: Local IP address on server
@@ -386,7 +386,7 @@ rpcpassword = hunter1
 # Public WS port - 'public_ws_port' - DEFAULT: The first 'ws' port configured
 #
 # The server's public WS (Web Socket) port. This, along with 'hostname' and the
-# varous 'public_*_port' variables are announced to clients and to other servers
+# various 'public_*_port' variables are announced to clients and to other servers
 # engaged in peer discovery. The default for this variable is to simply use the
 # first WS port specified in the server configuration (if any). If you are
 # behind a firewall and doing some port remapping, then you definitely want to
@@ -401,7 +401,7 @@ rpcpassword = hunter1
 # Public WSS port - 'public_wss_port' - DEFAULT: The first 'wss' port configured
 #
 # The server's public WSS (Web Socket Secure) port. This, along with 'hostname'
-# and the varous 'public_*_port' variables are announced to clients and to other
+# and the various 'public_*_port' variables are announced to clients and to other
 # servers engaged in peer discovery. The default for this variable is to simply
 # use the first WSS port specified in the server configuration (if any). If you
 # are behind a firewall and doing some port remapping, then you definitely want
@@ -449,7 +449,7 @@ rpcpassword = hunter1
 
 # Tor hostname - 'tor_hostname' - DEFAULT: Nothing
 #
-# If specifeid, and if you have a Tor proxy configured, and if you have at least
+# If specified, and if you have a Tor proxy configured, and if you have at least
 # one of tor_tcp_port and/or tor_ssl_port specified, then we will anounce this
 # host via Tor as a .onion host.  Note that this hostname must end in .onion.
 #
@@ -574,7 +574,7 @@ rpcpassword = hunter1
 # requests that have not yet returned results, and the number of such requests
 # hits this limit, then the client will be throttled for at least 200
 # milliseconds, or until the "low water mark" of extant request is reached
-# (whichever is longer). In other words, the throttling is acheived by pausing
+# (whichever is longer). In other words, the throttling is achieved by pausing
 # all further processing of requests for that client, until either 200 ms
 # has elapsed or the "low-water mark" for outstanding requests (default 20) is
 # hit. The default value (50) for this burst parameter is a decent value that is
@@ -781,7 +781,7 @@ rpcpassword = hunter1
 # address histories from impacting the performance of the server and using up
 # resources. Moreover, it can be argued that such users with such
 # computationally expensive histories are better served running a full node
-# themesleves, rather than relying on a public SPV server and/or light wallet
+# themseleves, rather than relying on a public SPV server and/or light wallet
 # system.
 #
 # Note that there are some addresses on the chain whose histories exceed 7.5


### PR DESCRIPTION
Found a typo in `# PEER DISCOVERY AND PUBLIC SERVER OPTIONS` and hence ran a spell-check 