### PR TITLE
Blocks DL: Improve reliability of bitcoind connection on slow systems or with huge blocks + misc fixes

### DIFF
--- a/src/AbstractConnection.cpp
+++ b/src/AbstractConnection.cpp
@@ -227,13 +227,16 @@ void AbstractConnection::on_connected()
     );
     {  // set up the "pingTimer"
         auto on_pingTimer = [this]{
-            if (Util::getTime() - lastGood > pingtime_ms)
-                // only call do_ping if we've been idle for longer than pingtime_ms
+            const auto diff = Util::getTime() - lastGood;
+            if constexpr (DEBUG_PINGTIMER) Debug(Log::Magenta) << "on_pingTimer: staleness = " << diff;
+            if (diff + 100 >= pingtime_ms)
+                // only call do_ping if we've been idle for longer than approximately pingtime_ms
+                // (+/- 100 msec, since we are using a CoarseTimer)
                 do_ping();
             return true;
         };
         const int period_ms = pingtime_ms/* default: 1 minute */ / 2;
-        callOnTimerSoon(period_ms, pingTimer, on_pingTimer, true, Qt::TimerType::VeryCoarseTimer); // method inherited from TimersByNameMixin
+        callOnTimerSoon(period_ms, pingTimer, on_pingTimer, true, Qt::TimerType::CoarseTimer); // method inherited from TimersByNameMixin
     }
 }
 

--- a/src/AbstractConnection.cpp
+++ b/src/AbstractConnection.cpp
@@ -228,7 +228,7 @@ void AbstractConnection::on_connected()
     {  // set up the "pingTimer"
         auto on_pingTimer = [this]{
             const auto diff = Util::getTime() - lastGood;
-            if constexpr (DEBUG_PINGTIMER) Debug(Log::Magenta) << "on_pingTimer: staleness = " << diff;
+            if constexpr (DEBUG_PINGS) Debug(Log::Magenta) << "on_pingTimer: staleness = " << diff;
             if (diff + 100 >= pingtime_ms)
                 // only call do_ping if we've been idle for longer than approximately pingtime_ms
                 // (+/- 100 msec, since we are using a CoarseTimer)

--- a/src/AbstractConnection.h
+++ b/src/AbstractConnection.h
@@ -34,7 +34,7 @@ class AbstractConnection : public QObject, public IdMixin, public TimersByNameMi
     Q_OBJECT
 public:
     static constexpr qint64 DEFAULT_MAX_BUFFER = 64*1024*1024; ///< 64MB, may change default in derived classes by setting maxBuffer in c'tor TODO: tune this.
-    static constexpr bool DEBUG_PINGS = true; ///< set this to true to debug the "staleness" / "pingtimer" mechanism
+    static constexpr bool DEBUG_PINGS = false; ///< set this to true to debug the "staleness" / "pingtimer" mechanism
 
     explicit AbstractConnection(IdMixin::Id id, QObject *parent = nullptr, qint64 maxBuffer = DEFAULT_MAX_BUFFER);
 

--- a/src/AbstractConnection.h
+++ b/src/AbstractConnection.h
@@ -34,7 +34,7 @@ class AbstractConnection : public QObject, public IdMixin, public TimersByNameMi
     Q_OBJECT
 public:
     static constexpr qint64 DEFAULT_MAX_BUFFER = 64*1024*1024; ///< 64MB, may change default in derived classes by setting maxBuffer in c'tor TODO: tune this.
-    static constexpr bool DEBUG_PINGTIMER = true; ///< set this to true to debug the "staleness" / "pingtimer" mechanism
+    static constexpr bool DEBUG_PINGS = true; ///< set this to true to debug the "staleness" / "pingtimer" mechanism
 
     explicit AbstractConnection(IdMixin::Id id, QObject *parent = nullptr, qint64 maxBuffer = DEFAULT_MAX_BUFFER);
 

--- a/src/AbstractConnection.h
+++ b/src/AbstractConnection.h
@@ -34,6 +34,7 @@ class AbstractConnection : public QObject, public IdMixin, public TimersByNameMi
     Q_OBJECT
 public:
     static constexpr qint64 DEFAULT_MAX_BUFFER = 64*1024*1024; ///< 64MB, may change default in derived classes by setting maxBuffer in c'tor TODO: tune this.
+    static constexpr bool DEBUG_PINGTIMER = true; ///< set this to true to debug the "staleness" / "pingtimer" mechanism
 
     explicit AbstractConnection(IdMixin::Id id, QObject *parent = nullptr, qint64 maxBuffer = DEFAULT_MAX_BUFFER);
 

--- a/src/BitcoinD.cpp
+++ b/src/BitcoinD.cpp
@@ -590,13 +590,15 @@ void BitcoinDMgr::submitRequest(QObject *sender, const RPC::Message::Id &rid, co
     context->setObjectName(QStringLiteral("context for '%1' request id: %2").arg(sender ? sender->objectName() : QString{}, rid.toString()));
 
     // result handler (runs in sender thread), captures context and keeps it alive as long as signal/slot connection is alive
-    connect(context.get(), &ReqCtxObj::results, sender, [context, resf, sender, method, params, timeout](const RPC::Message &response) {
+    connect(context.get(), &ReqCtxObj::results, sender, [context, resf, sender/*, method, params, timeout*/](const RPC::Message &response) {
         // Debug code for troubleshooting the extent of bitcoind backlogs in servicing requests
+        /*
         const auto now = Util::getTime();
         if (const auto diff = now - context->ts; diff > 5000) {
             Debug(Log::Green) << context->objectName() << " took " << diff << " msec (timeout was: " << timeout
                               << "), method: " << method << ", params: " << Json::serialize(params);
         }
+        */
         if (!context->replied.exchange(true) && resf)
             resf(response);
         // kill lambdas and shared_ptr captures, should cause deleter to execute

--- a/src/BitcoinD.h
+++ b/src/BitcoinD.h
@@ -31,6 +31,7 @@
 #include <QVariantMap>
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <set>
 #include <shared_mutex>
@@ -52,6 +53,7 @@ struct BitcoinDInfo {
     bool isCore = false; ///< true if we are actually connected to /Satoshi.. node (Bitcoin Core)
     bool isLTC = false; ///< true if we are actually connected to /LitecoinCore.. node (Litecoin)
     bool isBU = false; ///< true if subversion string starts with "/BCH Unlimited:"
+    bool isFlowee = false; ///< true if subversion string starts with "/Flowee"
     bool lacksGetZmqNotifications = false; ///< true if bchd or BU < 1.9.1.0, or if we got an RPC error the last time we queried
     bool hasDSProofRPC = false; ///< true if the RPC query to `getdsprooflist` didn't return an error.
 
@@ -148,6 +150,9 @@ signals:
     /// via getzmqnotifications). Note: this is never emitted if we are compiled without zmq support.
     void zmqNotificationsChanged(BitcoinDZmqNotifications);
 
+    /// Emitted whenever we detected the optimal ping method to use: "uptime" (fast)  or "help help" (slower, more compatible)
+    void detectedFastPingMethod(bool fast);
+
 protected:
     Stats stats() const override; // from Mgr
 
@@ -243,6 +248,10 @@ public:
     /// the specified interval.
     void resetPingTimer(int time_ms);
 
+public slots:
+    /// Connected to BitcoinDMgr::detectedFastPingMethod (via AutoConnection -> QueuedConnection)
+    void on_detectedFastPingMethod(bool b) { fastPing = b; }
+
 signals:
     /// This is emitted immediately after successful socket connect but before auth. After this signal, client code
     /// can expect either one of the two following signals to be emitted: either the authenticated() signal below,
@@ -254,7 +263,7 @@ protected:
     void on_started() override;
     void on_connected() override;
 
-    void do_ping() override; // testing
+    void do_ping() override;
 
     void reconnect();
 
@@ -266,6 +275,7 @@ private:
 
     const BitcoinD_RPCInfo rpcInfo;
     std::atomic_bool badAuth = false, needAuth = true;
+    bool fastPing = false;
 };
 
 

--- a/src/BitcoinD.h
+++ b/src/BitcoinD.h
@@ -200,6 +200,10 @@ private:
     /// called whenever bitcoind comes back alive, updates bitcoinDInfo.hasDSProofRPC
     void probeBitcoinDHasDSProofRPC();
 
+    /// called whenever bitcoind comes back alive, detects whether bitcoind has the 'uptime' RPC call. And if so,
+    /// emits detectedFastPingMethod(true), otherwise emits detectedFastPingMethod(false) if it lacks the RPC.
+    void probeBitcoinDHasUptimeRPC();
+
     /// Calls resetPingTimer on each BitcionD -- used by quirk fixup code since bchd vs bitcoind require different
     /// pingtimes
     void resetPingTimers(int timeout_ms);

--- a/src/BitcoinD.h
+++ b/src/BitcoinD.h
@@ -153,6 +153,11 @@ signals:
     /// Emitted whenever we detected the optimal ping method to use: "uptime" (fast)  or "help help" (slower, more compatible)
     void detectedFastPingMethod(bool fast);
 
+    /// Emitted by Controller whenever a block download starts and ends. This ends up controlling whether BitcoinD's
+    /// disconnect the socket if they go "stale". Sometimes we get spurious "staleness" in BitcoinD when it's busy
+    /// servicing a getblock request.  So during block download, we never disconnect if "stale".
+    void inBlockDownload(bool b);
+
 protected:
     Stats stats() const override; // from Mgr
 
@@ -251,6 +256,7 @@ public:
 public slots:
     /// Connected to BitcoinDMgr::detectedFastPingMethod (via AutoConnection -> QueuedConnection)
     void on_detectedFastPingMethod(bool b) { fastPing = b; }
+    void on_inBlockDownload(bool b);
 
 signals:
     /// This is emitted immediately after successful socket connect but before auth. After this signal, client code
@@ -276,6 +282,7 @@ private:
     const BitcoinD_RPCInfo rpcInfo;
     std::atomic_bool badAuth = false, needAuth = true;
     bool fastPing = false;
+    bool inBlockDownload = false;
 };
 
 

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -1717,7 +1717,7 @@ void CtlTask::on_failure(const RPC::Message::Id &id, const QString &msg)
     emit errored();
 }
 quint64 CtlTask::submitRequest(const QString &method, const QVariantList &params, const ResultsF &resultsFunc,
-                               const ErrorF &errorFunc, unsigned timeOutDelta)
+                               const ErrorF &errorFunc, const int timeOutOverride)
 {
     quint64 id = IdMixin::newId();
     using ErrorF = BitcoinDMgr::ErrorF;
@@ -1728,7 +1728,7 @@ quint64 CtlTask::submitRequest(const QString &method, const QVariantList &params
                                         ? ErrorF([this](MsgCRef m){ on_error(m); }) // more common case, just emit error on RPC error reply
                                         : errorFunc,
                                     [this](const RPC::Message::Id &id, const QString &msg){ on_failure(id, msg); },
-                                    reqTimeout + int(timeOutDelta));
+                                    timeOutOverride > 0 ? timeOutOverride : reqTimeout);
     return id;
 }
 

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -261,7 +261,7 @@ protected:
     using ResultsF = BitcoinDMgr::ResultsF;
     using ErrorF = BitcoinDMgr::ErrorF;
     quint64 submitRequest(const QString &method, const QVariantList &params, const ResultsF &resultsFunc,
-                          const ErrorF &errorFunc = {}, unsigned timeOutDelta = 0);
+                          const ErrorF &errorFunc = {}, int timeoutOverride = -1 /* <=0 -> no override */);
 
     Controller * const ctl; ///< initted in c'tor. Is always valid since all tasks' lifecycles are managed by the Controller.
     const int reqTimeout; ///< initted in c'tor, cached from ctl->options->bdTimeout

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -163,7 +163,7 @@ private:
     mutable std::shared_mutex smLock;
 
     std::unordered_map<CtlTask *, std::unique_ptr<CtlTask>, Util::PtrHasher> tasks;
-    size_t nDLBlocksTasks = 0;
+    int nDLBlocksTasks = 0;
 
     void add_DLBlocksTask(unsigned from, unsigned to, size_t nTasks);
     void process_DownloadingBlocks();

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -106,6 +106,9 @@ signals:
     /// set in a thread-safe manner
     void ignoreMempoolTxn(const QByteArray & txhash);
 
+    /// Emitted whenever we begin downloading blocks, and whenever we end the last DownloadBlocksTask (for whatever reason)
+    void downloadingBlocks(bool b);
+
 protected:
     Stats stats() const override; // from StatsMixin
     Stats debug(const StatsParams &) const override; // from StatsMixin
@@ -160,6 +163,7 @@ private:
     mutable std::shared_mutex smLock;
 
     std::unordered_map<CtlTask *, std::unique_ptr<CtlTask>, Util::PtrHasher> tasks;
+    size_t nDLBlocksTasks = 0;
 
     void add_DLBlocksTask(unsigned from, unsigned to, size_t nTasks);
     void process_DownloadingBlocks();
@@ -261,10 +265,10 @@ protected:
     using ResultsF = BitcoinDMgr::ResultsF;
     using ErrorF = BitcoinDMgr::ErrorF;
     quint64 submitRequest(const QString &method, const QVariantList &params, const ResultsF &resultsFunc,
-                          const ErrorF &errorFunc = {}, int timeoutOverride = -1 /* <=0 -> no override */);
+                          const ErrorF &errorFunc = {});
 
     Controller * const ctl; ///< initted in c'tor. Is always valid since all tasks' lifecycles are managed by the Controller.
-    const int reqTimeout; ///< initted in c'tor, cached from ctl->options->bdTimeout
+    int reqTimeout; ///< initted in c'tor, cached from ctl->options->bdTimeout. DownloadBlocksTask overrides this with a custom value if doing multi-block DL
 };
 
 Q_DECLARE_METATYPE(CtlTask *);

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -54,20 +54,12 @@ public:
 
     inline bool isStopping() const { return stopFlag; }
 
-    /// Struct that captures the return values for `downloadTaskRecommendedThrottleTimeMsec`
-    struct RecThrottleTime {
-        unsigned backoffMs{}, ///< if nonzero, then throttle
-                 deltaReqTimeoutMs{}; ///< add this time in msec to the request timeout time
-    };
+    /// Returns a positive nonzero value if the calling download task should throttle because the backlog is too large.
+    /// In that case the caller should try again in the returned value ms.
+    /// If the return value is 0, the caller may proceed immediately to continue downloading headers.
     /// This function is not intended to be used by code outside this subsystem -- it is intended to be called by the
     /// internal DownloadBlocksTask only.
-    ///
-    /// Returns a positive nonzero value for `backoffMs` if the calling download task should throttle because the
-    /// backlog is too large. In that case the caller should try again in the returned value ms.  Otherwise, if the
-    /// returned backoffMs is 0, the caller may proceed immediately to continue downloading headers and/or blocks. In
-    /// that case, deltaReqTimeoutMs will be nonzero and will be a recommended amount of time for the BitcoinDMgr
-    /// request timeout delta (passed to submitRequest).
-    RecThrottleTime downloadTaskRecommendedThrottleTimeMsec(unsigned forBlockHeight) const;
+    unsigned downloadTaskRecommendedThrottleTimeMsec(unsigned forBlockHeight) const;
 
     QVariantMap statsDebug(const QMap<QString, QString> & params) const;
 
@@ -169,7 +161,7 @@ private:
 
     std::unordered_map<CtlTask *, std::unique_ptr<CtlTask>, Util::PtrHasher> tasks;
 
-    void add_DLHeaderTask(unsigned from, unsigned to, size_t nTasks);
+    void add_DLBlocksTask(unsigned from, unsigned to, size_t nTasks);
     void process_DownloadingBlocks();
     bool process_VerifyAndAddBlock(PreProcessedBlockPtr); ///< helper called from within DownloadingBlocks state -- makes sure block is sane and adds it to db
     void process_PrintProgress(unsigned height, size_t nTx, size_t nIns, size_t nOuts, size_t nSH);

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -882,6 +882,7 @@ namespace RPC {
                 nReceived += data.size();
                 data = data.simplified();
                 TraceM(__func__, " Got: ", data);
+                lastGood = Util::getTime(); // update "last good" here to avoid going stale
                 if (sm->state == St::BEGIN) {
                     // read "HTTP/1.1 200 OK" line
                     auto toks = data.split(' ');


### PR DESCRIPTION
This PR should fix issue #116.  It also addresses the [Bitcoin Verde Scaling Report](https://docs.google.com/document/d/1tTzqZ4umSOvO7f92dtz05pcjOgqXfeQqVgBOtOzCvVA) dated May 2022 which revealed that Fulcrum has some issues downloading very large blocks (256MB+) in a series.  The two issues are related, and are basically because the following could happen on a slow HDD system or with a bitcoind that is serving up very large blocks:

- Fulcrum's "pingTimer" was inherently making a slow call,`ping`, every 10 seconds to keep the bitcoind connection "alive". This call didn't do what I assumed it does. :) This call would take locks and sometimes not return right away.
  - The "no-op" RPC call is now no longer `ping`, but is instead either `uptime` if it is available or `help help` as a fallback.
  - This makes it so that "pinging" bitcoind should at least return right away and not take any locks and block.
- Even so, it's sometimes possible for bitcoind to not respond to "pings" in a timely manner if it is backlogged servicing `getblock` requests for large blocks or on a slow HDD system.
  - As a result, we added a mechanism for the `BitcoinDMgr` to get notified when a multi-block download is underway, so as to disable the "staleness" auto-reconnect mechanism for its `BitcoinD` instances that it manages for the duration of the multi-block download.
    - This should fix the possibility of spurious "Stale connection, reconnecting" errors leading to random disconnects (see issue #116).
  - Additionally, "staleness" is now defined as `pingtime_ms * 3 + 100`  (so 30 seconds + 100 msec fuzz), whereas before it was a hard `pingtime_ms * 2` (20 seconds, no fuzz). Making the "staleness" value slightly more generous by default should be ok and avoid any possible spurious "Stale connection, reconnecting" errors in Fulcrum, should bitcoind prove to be a bit "busy".
- An additional problem that contributed to #116 and also the Verde report's poor measured performance was that the "RPC request timer" for `getblock` requests to bitcoind had a 30 second timeout.  During a multi-block DL on HDD or for very large blocks, we enqueue 100 - 1000 of these requests to bitcoind at a time, and it's not guaranteed that they *all* will return in under 30 seconds!  This is actually ok -- the backlog is just there to efficiently enqueue requests to bitcoind.  However, this created a problem in that Fulcrum would panic and assume the remote bitcoind instance was "dead", all the while it was in the middle of downloading blocks from it!
  - This has been fixed by basically making a special exception when doing a multi-block DL, that requests for `getblock` and `getblockhash` originating from the `DownloadBlocksTask` don't use the `bitcoind_timeout` parameter specified in the conf file, but always use the maximum possible value (600 seconds = 10 mins).

Additionally this PR contains additional small code nits and other assorted fixups.
