### PR TITLE
Expand Fulcrum API to more adequately support CashTokens and return `token_data`

### DIFF
--- a/contrib/rpm/fulcrum.spec
+++ b/contrib/rpm/fulcrum.spec
@@ -1,5 +1,5 @@
 Name:    {{{ git_repo_name name="fulcrum" }}}
-Version: 1.8.2
+Version: 1.9.0
 Release: {{{ git_repo_version }}}%{?dist}
 Summary: A fast & nimble SPV server for Bitcoin Cash & Bitcoin BTC
 

--- a/doc/unix-man-page.md
+++ b/doc/unix-man-page.md
@@ -1,6 +1,6 @@
-% FULCRUM(1) Version 1.8.2 | Fulcrum Manual
+% FULCRUM(1) Version 1.9.0 | Fulcrum Manual
 % Fulcrum is written by Calin Culianu (cculianu)
-% October 05, 2022
+% December 15, 2022
 
 # NAME
 

--- a/resources/bch/servers.json
+++ b/resources/bch/servers.json
@@ -65,11 +65,6 @@
         "t": "50001",
         "version": "1.4.3"
     },
-    "ec-bcn.criptolayer.net": {
-        "pruning": "-",
-        "s": "50212",
-        "version": "1.4.1"
-    },
     "electrumx-cash.1209k.com": {
         "pruning": "-",
         "s": "50002",
@@ -144,7 +139,7 @@
         "t": "50001",
         "version": "1.4.4"
     },
-    "bch.ninja": {
+    "cashnode.bch.ninja": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",

--- a/resources/bch/servers_chipnet.json
+++ b/resources/bch/servers_chipnet.json
@@ -10,5 +10,9 @@
     "chipnet.imaginary.cash": {
         "t": "50001",
         "s": "50002"
+    },
+    "ryzen.electroncash.de": {
+        "t": "50001",
+        "s": "50002"
     }
 }

--- a/src/BTC.cpp
+++ b/src/BTC.cpp
@@ -210,7 +210,7 @@ namespace BTC
         return Coin::Unknown;
     }
 
-    bitcoin::token::OutputDataPtr DeserializeTokenDataWithPrefix(const QByteArray &ba, int pos, int *pos_out) {
+    bitcoin::token::OutputDataPtr DeserializeTokenDataWithPrefix(const QByteArray &ba, int pos) {
         bitcoin::token::OutputDataPtr ret;
         if (ba.size() - pos > 0) {
             // attempt to deserialize token data
@@ -221,7 +221,7 @@ namespace BTC
             ret.emplace();
             BTC::Deserialize<bitcoin::token::OutputData>(*ret, ba, pos , false, false,
                                                          true /* cashTokens */,
-                                                         pos_out == nullptr /* noJunkAtEnd */, pos_out);
+                                                         true /* noJunkAtEnd */);
         }
         return ret;
     }

--- a/src/BTC.h
+++ b/src/BTC.h
@@ -90,8 +90,7 @@ namespace BTC
               /// (use the non-in-place specialization instead)
               std::enable_if_t<!std::is_same_v<BitcoinObject, bitcoin::CTransaction>, int> = 0 >
     void Deserialize(BitcoinObject &thing, const QByteArray &bytes, int pos = 0, bool allowSegWit = false,
-                     bool allowMW = false, bool allowCashTokens = true, bool throwIfJunkAtEnd = false,
-                     int *pos_out = nullptr)
+                     bool allowMW = false, bool allowCashTokens = true, bool throwIfJunkAtEnd = false)
     {
         int version = bitcoin::PROTOCOL_VERSION;
         if (allowSegWit) version |= bitcoin::SERIALIZE_TRANSACTION_USE_WITNESS;
@@ -99,17 +98,16 @@ namespace BTC
         if (allowCashTokens) version |= bitcoin::SERIALIZE_TRANSACTION_USE_CASHTOKENS;
         bitcoin::GenericVectorReader<QByteArray> vr(bitcoin::SER_NETWORK, version, bytes, pos);
         thing.Unserialize(vr);
-        if (pos_out) *pos_out = bytes.size() - int(vr.size());
         if (throwIfJunkAtEnd && !vr.empty())
             throw std::ios_base::failure("Got unprocessed bytes at the end when deserializeing a bitcoin object");
     }
     /// Convenience for above.  Create an instance of object and deserialize to it
     template <typename BitcoinObject>
     BitcoinObject Deserialize(const QByteArray &bytes, int pos = 0, bool allowSegWit = false, bool allowMW = false,
-                              bool allowCashTokens = true, bool noJunkAtEnd = false, int *pos_out = nullptr)
+                              bool allowCashTokens = true, bool noJunkAtEnd = false)
     {
         BitcoinObject ret;
-        Deserialize(ret, bytes, pos, allowSegWit, allowMW, allowCashTokens, noJunkAtEnd, pos_out);
+        Deserialize(ret, bytes, pos, allowSegWit, allowMW, allowCashTokens, noJunkAtEnd);
         return ret;
     }
 
@@ -126,11 +124,11 @@ namespace BTC
 
     /// Template specialization for CTransaction which has const fields and works a little differently
     template <> inline bitcoin::CTransaction Deserialize(const QByteArray &ba, int pos, bool allowSegWit, bool allowMW,
-                                                         bool allowCashTokens, bool noJunkAtEnd, int *pos_out)
+                                                         bool allowCashTokens, bool noJunkAtEnd)
     {
         // This *does* move the vectors from CMutableTransaction -> CTransaction
         return bitcoin::CTransaction{Deserialize<bitcoin::CMutableTransaction>(ba, pos, allowSegWit, allowMW,
-                                                                               allowCashTokens, noJunkAtEnd, pos_out)};
+                                                                               allowCashTokens, noJunkAtEnd)};
     }
 
     /// Convenience to deserialize segwit object (block or tx) (Core only)
@@ -148,10 +146,10 @@ namespace BTC
     }
 
     /// Used for scripthash_unspent db value and/or for TXOInfo inside utxoset db. May throw on deser failure or will
-    /// return a null object if `pos` is at end already. If `pos_out` is `nullptr`, will throw if there is junk at
-    /// the end after deserialization. If `pos_out` not is `nullptr`, will just update `*pos_out` with the position
-    /// after the last byte consumed (and thus will tolerate junk at the end).
-    bitcoin::token::OutputDataPtr DeserializeTokenDataWithPrefix(const QByteArray &ba, int pos, int *pos_out = nullptr);
+    /// return a null object if `pos` is at end already. Will throw if there is junk at the end after deserialization.
+    /// If the passed-in `ba` is not empty, the first byte MUST be bitcoin::token::PREFIX_BYTE otherwise this throws.
+    /// The number of bytes consumed is always ba.length().
+    bitcoin::token::OutputDataPtr DeserializeTokenDataWithPrefix(const QByteArray &ba, int pos);
     /// Appends prefix + token data to the end of byte stream `ba`. Will pre-reserve space first. May throw (unlikely).
     void SerializeTokenDataWithPrefix(QByteArray &ba, const bitcoin::token::OutputData *ptokenData);
 

--- a/src/BlockProc.cpp
+++ b/src/BlockProc.cpp
@@ -62,10 +62,10 @@ void PreProcessedBlock::fill(BlockHeight blockHeight, size_t blockSize, const bi
         IONum outN = 0;
         for (const auto & out : tx->vout) {
             // save the outputs seen
-            outputs.emplace_back(
+            outputs.push_back(
                 OutPt{ unsigned(txIdx), outN, out.nValue, {}, out.tokenDataPtr }
             );
-            estimatedThisSizeBytes += sizeof(OutPt);
+            estimatedThisSizeBytes += sizeof(OutPt) + (out.tokenDataPtr ? out.tokenDataPtr->GetMemSize() : 0u);
             const size_t outputIdx = outputs.size()-1;
             if (const auto cscript = out.scriptPubKey;
                     !BTC::IsOpReturn(cscript))  ///< skip OP_RETURN

--- a/src/BlockProc.cpp
+++ b/src/BlockProc.cpp
@@ -63,7 +63,7 @@ void PreProcessedBlock::fill(BlockHeight blockHeight, size_t blockSize, const bi
         for (const auto & out : tx->vout) {
             // save the outputs seen
             outputs.emplace_back(
-                OutPt{ unsigned(txIdx), outN, out.nValue, {} }
+                OutPt{ unsigned(txIdx), outN, out.nValue, {}, out.tokenDataPtr }
             );
             estimatedThisSizeBytes += sizeof(OutPt);
             const size_t outputIdx = outputs.size()-1;
@@ -203,7 +203,10 @@ QString PreProcessedBlock::toDebugString() const
             }
             for (size_t j = 0; j < ag.outs.size(); ++j) {
                 const auto idx = ag.outs[j];
-                ts << " {out# " << j << " - " << txHashForOutputIdx(idx).toHex() << ":" << outputs[idx].outN << " amt: " << outputs[idx].amount.ToString().c_str() << " }";
+                ts << " {out# " << j << " - " << txHashForOutputIdx(idx).toHex() << ":" << outputs[idx].outN
+                   << " amt: " << outputs[idx].amount.ToString().c_str()
+                   << " tok: " << (outputs[idx].tokenDataPtr ? outputs[idx].tokenDataPtr->ToString().c_str() : "")
+                   << " }";
             }
             ts << ")";
             ++i;

--- a/src/BlockProc.h
+++ b/src/BlockProc.h
@@ -65,6 +65,7 @@ struct PreProcessedBlock
         IONum outN = 0; ///< this is an index into the tx's vout vector (*NOT* this class's `outputs`!) (again, tx's can't have more than ~111k inputs -- if that changes, fixme!)
         bitcoin::Amount amount;
         std::optional<unsigned> spentInInputIndex; ///< if has_value, the output was spent this block in input index (index into the `inputs` array)
+        bitcoin::token::OutputDataPtr tokenDataPtr;
     };
 
     struct InputPt {

--- a/src/Common.h
+++ b/src/Common.h
@@ -39,7 +39,7 @@ struct InternalError : Exception { using Exception::Exception; ~InternalError() 
 struct BadArgs : Exception { using Exception::Exception; ~BadArgs() override; };
 
 #define APPNAME "Fulcrum"
-#define VERSION "1.8.2"
+#define VERSION "1.9.0"
 #ifdef QT_DEBUG
 inline constexpr bool isReleaseBuild() { return false; }
 #else

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -1912,6 +1912,20 @@ auto Controller::debug(const StatsParams &p) const -> Stats // from StatsMixin
             l.push_back(Server::unspentItemToVariantMap(item));
         ret["unspent_debug"] = l;
     }
+    if (p.contains("utxo_stats")) {
+        // Note: This is slow and times-out on mainnet or even testnet3. Was mainly used for testing on chipnet.
+        const auto stats = storage->calcUTXOSetStats([](size_t ctr){ DebugM("utxo_stats: progress counter = ", ctr); });
+        QVariantMap m;
+        m["block_height"] = qlonglong(stats.block_height);
+        m["block_hash"] = QString::fromLatin1(stats.block_hash.toHex());
+        m["utxo_db_ct"] = qlonglong(stats.utxo_db_ct);
+        m["utxo_db_size_bytes"] = qlonglong(stats.utxo_db_size_bytes);
+        m["utxo_db_shasum"] = QString::fromLatin1(stats.utxo_db_shasum.toHex());
+        m["shunspent_db_ct"] = qlonglong(stats.shunspent_db_ct);
+        m["shunspent_db_size_bytes"] = qlonglong(stats.shunspent_db_size_bytes);
+        m["shunspent_db_shasum"] = QString::fromLatin1(stats.shunspent_db_shasum.toHex());
+        ret["utxo_stats"] = m;
+    }
     if (p.contains("mempool")) {
         auto [mempool, lock] = storage->mempool();
         ret["mempool_debug"] = mempool.dump();

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -1627,7 +1627,7 @@ void Controller::process_PrintProgress(unsigned height, size_t nTx, size_t nIns,
 
 void Controller::process_DownloadingBlocks()
 {
-    unsigned ct = 0;
+    unsigned ct [[maybe_unused]] = 0;
 
     for (auto it = sm->ppBlocks.find(sm->ppBlkHtNext); it != sm->ppBlocks.end() && !stopFlag; it = sm->ppBlocks.find(sm->ppBlkHtNext)) {
         auto ppb = it->second;
@@ -1907,15 +1907,9 @@ auto Controller::debug(const StatsParams &p) const -> Stats // from StatsMixin
     if (const auto hashx = QByteArray::fromHex(p.value("unspent").toLatin1()); hashx.length() == HashLen) {
         QVariantList l;
 
-        auto items = storage->listUnspent(hashx);
-        for (const auto & item : items) {
-            QVariantMap m;
-            m["tx_hash"] = Util::ToHexFast(item.hash);
-            m["height"] = item.height;
-            m["tx_pos"] = item.tx_pos;
-            m["value"] = qlonglong(item.value / item.value.satoshi());
-            l.push_back(m);
-        }
+        const auto items = storage->listUnspent(hashx, Storage::TokenFilterOption::IncludeTokens);
+        for (const auto & item : items)
+            l.push_back(Server::unspentItemToVariantMap(item));
         ret["unspent_debug"] = l;
     }
     if (p.contains("mempool")) {

--- a/src/Mempool.cpp
+++ b/src/Mempool.cpp
@@ -678,13 +678,19 @@ QVariantMap Mempool::dumpTx(const TxRef &tx)
         m["fee"] = tx->fee.ToString().c_str();
         m["hasUnconfirmedParentTx"] = tx->hasUnconfirmedParentTx;
         static const auto TXOInfo2Map = [](const TXOInfo &info) -> QVariantMap {
-            return QVariantMap{
+            QVariantMap ret{
                 { "amount", QString::fromStdString(info.amount.ToString()) },
                 { "scriptHash", info.hashX.toHex() },
                 // NEW -- it's useful to see this info in mempool debug to catch bugs
                 { "confirmedHeight", info.confirmedHeight ? QVariant(qlonglong(*info.confirmedHeight)) : QVariant()},
                 { "txNum", qlonglong(info.txNum)},
             };
+            if (info.tokenDataPtr) {
+                QByteArray ba;
+                BTC::SerializeTokenDataWithPrefix(ba, info.tokenDataPtr.get());
+                ret.insert("tokenData", ba.toHex());
+            }
+            return ret;
         };
         QVariantMap txos;
         IONum num = 0;

--- a/src/Mempool.cpp
+++ b/src/Mempool.cpp
@@ -103,7 +103,7 @@ auto Mempool::addNewTxs(ScriptHashesAffectedSet & scriptHashesAffected,
                 }
                 // end memory saving hack
                 TXOInfo &txoInfo = tx->txos[n];
-                txoInfo = TXOInfo{out.nValue, sh, {}, {}};
+                txoInfo = TXOInfo{out.nValue, sh, {}, {}, out.tokenDataPtr};
                 auto & utxoset = tx->hashXs[sh].utxo;
                 utxoset.emplace_hint(utxoset.end(), n);
                 hxit->second.push_back(tx); // save tx to hashx -> tx vector (amortized constant time insert at end -- we will sort and uniqueify this at end of this function)
@@ -129,7 +129,8 @@ auto Mempool::addNewTxs(ScriptHashesAffectedSet & scriptHashesAffected,
             const IONum prevN = IONum(in.prevout.GetN());
             const TxHash prevTxId = BTC::Hash2ByteArrayRev(in.prevout.GetTxId());
             const TXO prevTXO{prevTxId, prevN};
-            TXOInfo prevInfo;
+            std::optional<TXOInfo> optTXOInfo;
+            const TXOInfo *pprevInfo{}; // points to either a TXOInfo from a prevTxRef, or to &*optTXOInfo
             QByteArray sh; // shallow copy of prevInfo.hashX
             if (auto it = this->txs.find(prevTxId); it != this->txs.end()) {
                 // prev is a mempool tx
@@ -137,18 +138,21 @@ auto Mempool::addNewTxs(ScriptHashesAffectedSet & scriptHashesAffected,
                 auto prevTxRef = it->second;
                 assert(bool(prevTxRef));
                 if (prevN >= prevTxRef->txos.size()
-                        || !(prevInfo = prevTxRef->txos[prevN]).isValid())
+                        || !(pprevInfo = &prevTxRef->txos[prevN])->isValid())
                     // defensive programming paranoia
                     throw InternalError(QString("FAILED TO FIND A VALID PREVIOUS TXOUTN %1:%2 IN MEMPOOL for TxHash: %3 (input %4)")
                                         .arg(QString(prevTxId.toHex())).arg(prevN).arg(QString(hash.toHex())).arg(inNum));
-                sh = prevInfo.hashX;
-                tx->hashXs[sh].unconfirmedSpends[prevTXO] = prevInfo;
+                sh = pprevInfo->hashX;
+                const auto & refPrevInfo = tx->hashXs[sh].unconfirmedSpends[prevTXO] = *pprevInfo;
                 auto prevHashXIt = prevTxRef->hashXs.find(sh);
                 if (prevHashXIt == prevTxRef->hashXs.end())
                     throw InternalError(QString("PREV OUT %1 IS MISSING ITS HASHX ENTRY FOR HASHX %2 (txid: %3)")
                                         .arg(prevTXO.toString(), QString(sh.toHex()), QString(tx->hash.toHex())));
                 prevHashXIt->second.utxo.erase(prevN); // remove this spend from utxo set for prevTx in mempool
-                if (TRACE) Debug() << hash.toHex() << " unconfirmed spend: " << prevTXO.toString() << " " << prevInfo.amount.ToString().c_str();
+                if (TRACE) {
+                    Debug() << hash.toHex() << " unconfirmed spend: " << prevTXO.toString() << " " << refPrevInfo.amount.ToString().c_str()
+                            << (refPrevInfo.tokenDataPtr ? (" " + refPrevInfo.tokenDataPtr->ToString()).c_str() : "");
+                }
 
                 // DSP handling (BCH only)
                 if (!dsps.empty() && !seenParents.count(prevTxId)) {
@@ -186,7 +190,7 @@ auto Mempool::addNewTxs(ScriptHashesAffectedSet & scriptHashesAffected,
                 // /DSP handling
             } else {
                 // prev is a confirmed tx
-                const auto optTXOInfo = getTXOInfo(prevTXO); // this may also throw on low-level db error
+                optTXOInfo = getTXOInfo(prevTXO); // this may also throw on low-level db error
                 if (UNLIKELY(!optTXOInfo.has_value())) {
                     // Uh oh. If it wasn't in the mempool or in the db.. something is very wrong with our code...
                     // (or there maybe was a race condition and a new block came in while we were doing this).
@@ -195,24 +199,26 @@ auto Mempool::addNewTxs(ScriptHashesAffectedSet & scriptHashesAffected,
                     throw InternalError(QString("FAILED TO FIND PREVIOUS TX %1 IN EITHER MEMPOOL OR DB for TxHash: %2 (input %3)")
                                         .arg(prevTXO.toString()).arg(QString(hash.toHex())).arg(inNum));
                 }
-                prevInfo = *optTXOInfo;
-                sh = prevInfo.hashX;
+                pprevInfo = &*optTXOInfo;
+                sh = pprevInfo->hashX;
                 // hack to save memory by re-using existing sh QByteArray and/or forcing a shallow-copy
                 auto hxit = tx->hashXs.find(sh);
                 if (hxit != tx->hashXs.end()) {
                     // existing found, re-use same unerlying QByteArray memory for sh
-                    sh = prevInfo.hashX = hxit->first;
+                    sh = optTXOInfo->hashX = hxit->first;
                 } else {
                     // new entry, insert, update hxit
                     auto pair = tx->hashXs.emplace(std::piecewise_construct, std::forward_as_tuple(sh), std::forward_as_tuple());
                     hxit = pair.first;
                 }
                 // end memory saving hack
-                hxit->second.confirmedSpends[prevTXO] = prevInfo;
-                if (TRACE) Debug() << hash.toHex() << " confirmed spend: " << prevTXO.toString() << " " << prevInfo.amount.ToString().c_str();
+                const auto & refPrevInfo = hxit->second.confirmedSpends[prevTXO] = *pprevInfo;
+                if (TRACE) {
+                    Debug() << hash.toHex() << " confirmed spend: " << prevTXO.toString() << " " << refPrevInfo.amount.ToString().c_str();
+                }
             }
-            tx->fee += prevInfo.amount;
-            assert(sh == prevInfo.hashX);
+            tx->fee += pprevInfo->amount;
+            assert(sh == pprevInfo->hashX);
             this->hashXTxs[sh].push_back(tx); // mark this hashX as having been "touched" because of this input (note we push dupes here out of order but sort and uniqueify at the end)
             scriptHashesAffected.insert(sh);
             ++inNum;

--- a/src/PeerMgr.cpp
+++ b/src/PeerMgr.cpp
@@ -509,7 +509,6 @@ void PeerMgr::on_kickByAddress(const QHostAddress &addr)
 {
     if (addr.isNull())
         return;
-    int ctr = 0;
     QSet<QString> hostnames;
     // first, loop through all the inactive maps and search for this addr
     for (PeerInfoMap *m : {&seedPeers, &queued, &bad, &failed} ) {
@@ -518,7 +517,6 @@ void PeerMgr::on_kickByAddress(const QHostAddress &addr)
                 DebugM(__func__, " removing peer ", it.key(), " ", addr.toString());
                 hostnames.insert(it->hostName);
                 it = m->erase(it);
-                ++ctr;
             } else
                 ++it;
         }
@@ -530,7 +528,6 @@ void PeerMgr::on_kickByAddress(const QHostAddress &addr)
             hostnames.insert(c->info.hostName);
             c->wasKicked = true;
             c->deleteLater(); // this will call us back to remove it from the hashmap, etc
-            ++ctr;
         }
     }
     if (const auto uniqs = hostnames.size(); uniqs)
@@ -542,7 +539,6 @@ void PeerMgr::on_kickBySuffix(const QString &suffix)
     if (suffix.isEmpty())
         return;
     // NB: the suffix comes in pre-normalized from SrvMgr.
-    int ctr = 0;
     QSet<QString> hostnames;
     // first, loop through all the inactive maps and search for this addr
     for (PeerInfoMap *m : {&seedPeers, &queued, &bad, &failed} ) {
@@ -551,7 +547,6 @@ void PeerMgr::on_kickBySuffix(const QString &suffix)
                 DebugM(__func__, " removing peer ", it.key(), " ", it->hostName);
                 hostnames.insert(it->hostName);
                 it = m->erase(it);
-                ++ctr;
             } else
                 ++it;
         }
@@ -563,7 +558,6 @@ void PeerMgr::on_kickBySuffix(const QString &suffix)
             hostnames.insert(c->info.hostName);
             c->wasKicked = true;
             c->deleteLater(); // this will call us back to remove it from the hashmap, etc
-            ++ctr;
         }
     }
     if (const auto uniqs = hostnames.size(); uniqs)

--- a/src/PeerMgr.h
+++ b/src/PeerMgr.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "BlockProcTypes.h"
+#include "BTC.h"
 #include "Mixins.h"
 #include "Mgr.h"
 #include "RPC.h"
@@ -116,6 +117,8 @@ private:
     const std::shared_ptr<const Options> options; ///< from SrvMgr that creates us.
 
     QByteArray _genesisHash;
+
+    BTC::Coin coin = BTC::Coin::Unknown;
 
     bool hasip4 = false, hasip6 = false;
 

--- a/src/ServerMisc.cpp
+++ b/src/ServerMisc.cpp
@@ -4,8 +4,8 @@
 namespace ServerMisc
 {
     const Version MinProtocolVersion(1,4,0);
-    const Version MaxProtocolVersion(1,4,6);
-    const Version MinTokenAwareProtocolVersion(1,4,6);
+    const Version MaxProtocolVersion(1,5,0);
+    const Version MinTokenAwareProtocolVersion(1,5,0);
     const QString AppVersion(VERSION);
     const QString AppSubVersion = QString("%1 %2").arg(APPNAME, VERSION);
 }

--- a/src/ServerMisc.cpp
+++ b/src/ServerMisc.cpp
@@ -4,7 +4,8 @@
 namespace ServerMisc
 {
     const Version MinProtocolVersion(1,4,0);
-    const Version MaxProtocolVersion(1,4,5);
+    const Version MaxProtocolVersion(1,4,6);
+    const Version MinTokenAwareProtocolVersion(1,4,6);
     const QString AppVersion(VERSION);
-    const QString AppSubVersion = QString("%1 %2").arg(APPNAME).arg(VERSION);
+    const QString AppSubVersion = QString("%1 %2").arg(APPNAME, VERSION);
 }

--- a/src/ServerMisc.h
+++ b/src/ServerMisc.h
@@ -26,8 +26,11 @@ namespace ServerMisc
 {
     inline constexpr auto HashFunction = "sha256";
 
-    /// Used in various places to rejects old clients or incompatible peers. Currently 1.4 and 1.4.4 respectively.
+    /// Used in various places to rejects old clients or incompatible peers. Currently 1.4 and 1.4.6 respectively.
     extern const Version MinProtocolVersion, MaxProtocolVersion;
+    /// The first version where we expect clients to be "token aware" and thus we return token_data to them by default
+    /// in e.g. listunspent and get_balance: 1.4.6
+    extern const Version MinTokenAwareProtocolVersion;
 
     extern const QString AppVersion,  ///< in string form suitable for sending in protocol or banner e.g. "1.0"
                          AppSubVersion; ///< e.g. "Fulcrum 1.0"

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -1412,17 +1412,20 @@ Storage::TokenFilterOption Server::parseTokenFilterOptionCommon(const RPC::Messa
 void Server::rpc_blockchain_scripthash_get_balance(Client *c, const RPC::BatchId batchId, const RPC::Message &m)
 {
     const auto sh = parseFirstHashParamCommon(m);
-    impl_get_balance(c, batchId, m, sh);
+    const auto tf = parseTokenFilterOptionCommon(m, 1);
+    impl_get_balance(c, batchId, m, sh, tf);
 }
 void Server::rpc_blockchain_address_get_balance(Client *c, const RPC::BatchId batchId, const RPC::Message &m)
 {
     const auto sh = parseFirstAddrParamToShCommon(m);
-    impl_get_balance(c, batchId, m, sh);
+    const auto tf = parseTokenFilterOptionCommon(m, 1);
+    impl_get_balance(c, batchId, m, sh, tf);
 }
-void Server::impl_get_balance(Client *c, const RPC::BatchId batchId, const RPC::Message &m, const HashX &sh)
+void Server::impl_get_balance(Client *c, const RPC::BatchId batchId, const RPC::Message &m, const HashX &sh,
+                              const Storage::TokenFilterOption tokenFilter)
 {
-    generic_do_async(c, batchId, m.id, [sh, this] {
-        const auto [amt, uamt] = storage->getBalance(sh);
+    generic_do_async(c, batchId, m.id, [sh, tokenFilter, this] {
+        const auto [amt, uamt] = storage->getBalance(sh, tokenFilter);
         /* Note: ElectrumX protocol docs are incorrect. They claim a string in coin units is returned here.
          * It is not. Instead a number in satoshis is returned!
          * Incorrect docs: https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-balance */
@@ -2085,7 +2088,7 @@ HEY_COMPILER_PUT_STATIC_HERE(Server::StaticData::registry){
     { {"server.ping",                       true,               false,    PR{0,0},                    },          MP(rpc_server_ping) },
     { {"server.version",                    true,               false,    PR{0,2},                    },          MP(rpc_server_version) },
 
-    { {"blockchain.address.get_balance",    true,               false,    PR{1,1},                    },          MP(rpc_blockchain_address_get_balance) },
+    { {"blockchain.address.get_balance",    true,               false,    PR{1,2},                    },          MP(rpc_blockchain_address_get_balance) },
     { {"blockchain.address.get_history",    true,               false,    PR{1,1},                    },          MP(rpc_blockchain_address_get_history) },
     { {"blockchain.address.get_mempool",    true,               false,    PR{1,1},                    },          MP(rpc_blockchain_address_get_mempool) },
     { {"blockchain.address.get_scripthash", true,               false,    PR{1,1},                    },          MP(rpc_blockchain_address_get_scripthash) },
@@ -2099,7 +2102,7 @@ HEY_COMPILER_PUT_STATIC_HERE(Server::StaticData::registry){
     { {"blockchain.headers.subscribe",      true,               false,    PR{0,0},                    },          MP(rpc_blockchain_headers_subscribe) },
     { {"blockchain.relayfee",               true,               false,    PR{0,0},                    },          MP(rpc_blockchain_relayfee) },
 
-    { {"blockchain.scripthash.get_balance", true,               false,    PR{1,1},                    },          MP(rpc_blockchain_scripthash_get_balance) },
+    { {"blockchain.scripthash.get_balance", true,               false,    PR{1,2},                    },          MP(rpc_blockchain_scripthash_get_balance) },
     { {"blockchain.scripthash.get_history", true,               false,    PR{1,1},                    },          MP(rpc_blockchain_scripthash_get_history) },
     { {"blockchain.scripthash.get_mempool", true,               false,    PR{1,1},                    },          MP(rpc_blockchain_scripthash_get_mempool) },
     { {"blockchain.scripthash.listunspent", true,               false,    PR{1,2},                    },          MP(rpc_blockchain_scripthash_listunspent) },

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -2046,7 +2046,6 @@ void Server::rpc_blockchain_transaction_dsproof_unsubscribe(Client *c, const RPC
 void Server::rpc_blockchain_utxo_get_info(Client *c, const RPC::BatchId batchId, const RPC::Message &m)
 {
     const QVariantList l = m.paramsList();
-    assert(l.size() == 2);
 
     QByteArray txHash = validateHashHex( l.front().toString() ); // arg0: prevoutHash
     if (txHash.length() != HashLen)
@@ -2066,6 +2065,8 @@ void Server::rpc_blockchain_utxo_get_info(Client *c, const RPC::BatchId batchId,
             m["scripthash"] = QString(Util::ToHexFast(optInfo->hashX));
             if (optInfo->confirmedHeight.has_value())
                 m["confirmed_height"] = qlonglong(optInfo->confirmedHeight.value());
+            if (optInfo->tokenDataPtr)
+                m["token_data"] = tokenDataToVariantMap(*optInfo->tokenDataPtr);
             // NB: unconfirmed utxos will lack a "confirmed_height" entry
             ret = m;
         }

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -1399,7 +1399,7 @@ Storage::TokenFilterOption Server::parseTokenFilterOptionCommon(const RPC::Messa
         // unsupported on non-BCH
         throw RPCError("The token filtering option is only available on BCH", RPC::ErrorCodes::Code_InvalidParams);
     else if (!hasArg)
-        return Storage::TokenFilterOption::ExcludeTokens; // default: exclude tokens
+        return Storage::TokenFilterOption::IncludeTokens; // default: include tokens
     const auto arg = l[argPos].toString().trimmed().toLower();
     if (arg == QStringLiteral("exclude_tokens")) return Storage::TokenFilterOption::ExcludeTokens;
     else if (arg == QStringLiteral("include_tokens")) return Storage::TokenFilterOption::IncludeTokens;

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -324,7 +324,7 @@ public:
     /// which also needs a features dict when *it* calls add_peer on peer servers.
     /// NOTE: Be sure to only ever call this function from the same thread as the AbstractConnection (first arg) instance!
     static QVariantMap makeFeaturesDictForConnection(AbstractConnection *, const QByteArray &genesisHash,
-                                                     const Options & options, bool hasDSProofRPC);
+                                                     const Options & options, bool hasDSProofRPC, bool hasCashTokens);
 
     virtual QString prettyName() const override;
 
@@ -418,7 +418,7 @@ private:
     HashX parseFirstHashParamCommon(const RPC::Message &m, const char *const errMsg = nullptr) const;
 
     /// Helper used by blockchain.*.listunspent *.get_balance to parse optional 2nd arg
-    Storage::TokenFilterOption parseTokenFilterOptionCommon(const RPC::Message &m, size_t argPos) const;
+    Storage::TokenFilterOption parseTokenFilterOptionCommon(Client *c, const RPC::Message &m, size_t argPos) const;
 
     /// Basically a namespace for our rpc dispatch tables, etc
     struct StaticData {
@@ -632,6 +632,9 @@ public:
     double lastWarnedAboutSubsLimit = 0.; ///< used to throttle log messages when client hits subs limit
 
     static std::atomic_size_t numClients, numClientsMax, numClientsCtr; // number of connected clients: current, max lifetime, accumulated counter
+
+    /// Returns true iff the client is token aware (protocol version >= 1.4.6). Note that this only makese sense on BCH.
+    bool hasMinimumTokenAwareVersion() const;
 
 signals:
     /// Used by ServerBase via a direct connection.  The class d'tor emits this.  This is better for us than

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -417,6 +417,8 @@ private:
     /// it will throw RPCError in all parse/failure cases and only ever returns a valid hash on success.
     HashX parseFirstHashParamCommon(const RPC::Message &m, const char *const errMsg = nullptr) const;
 
+    /// Helper used by blockchain.*.listunspent *.get_balance to parse optional 2nd arg
+    Storage::TokenFilterOption parseTokenFilterOptionCommon(const RPC::Message &m, size_t argPos) const;
 
     /// Basically a namespace for our rpc dispatch tables, etc
     struct StaticData {

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -396,7 +396,7 @@ private:
 
     // Impl. for blockchain.scripthash.* & blockchain.address.* methods (both sets call into these).
     // Note: Validation should have already been done by caller.
-    void impl_get_balance(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash);
+    void impl_get_balance(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash, Storage::TokenFilterOption tokenFilter);
     void impl_get_history(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash);
     void impl_get_mempool(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash);
     void impl_listunspent(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash, Storage::TokenFilterOption tokenFilter);

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -366,7 +366,9 @@ private:
     void rpc_blockchain_block_header(Client *, RPC::BatchId, const RPC::Message &);  // fully implemented
     void rpc_blockchain_block_headers(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     void rpc_blockchain_estimatefee(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
+    void rpc_blockchain_headers_get_tip(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     void rpc_blockchain_headers_subscribe(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
+    void rpc_blockchain_headers_unsubscribe(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     void rpc_blockchain_relayfee(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     // scripthash
     void rpc_blockchain_scripthash_get_balance(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
@@ -623,7 +625,7 @@ public:
 
     std::shared_ptr<PerIPData> perIPData;
 
-    bool isSubscribedToHeaders = false;
+    QMetaObject::Connection headerSubConnection; ///< if valid, this client is subscribed to headers (`Server::newHeader` signal)
     std::atomic_int nShSubs{0};  ///< the number of unique scripthash subscriptions for this client.
 
     //bitcoind_throttle counter, per client

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -399,7 +399,7 @@ private:
     void impl_get_balance(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash);
     void impl_get_history(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash);
     void impl_get_mempool(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash);
-    void impl_listunspent(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash);
+    void impl_listunspent(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash, Storage::TokenFilterOption tokenFilter);
     void impl_generic_subscribe(SubsMgr *, Client *, RPC::BatchId, const RPC::Message &, const HashX &key,
                                 const std::optional<QString> & aliasUsedForNotifications = {});
     void impl_generic_unsubscribe(SubsMgr *, Client *, RPC::BatchId, const RPC::Message &, const HashX &key);
@@ -462,6 +462,11 @@ protected:
     };
     static std::weak_ptr<LogFilter> weakLogFilter;
     std::shared_ptr<LogFilter> logFilter;
+
+public:
+    /// Helper function called by blockchain.scripthash.listunspent RPC and by the Controller class for /debug/
+    /// @returns A QVariantMap that matches the output of `blockchain.scripthash.listunspent`
+    [[nodiscard]] static QVariantMap unspentItemToVariantMap(const Storage::UnspentItem &);
 };
 
 /// SSL version of the above Server class that just wraps tcp sockets with a QSslSocket.

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -4007,11 +4007,11 @@ auto Storage::calcUTXOSetStats(const DumpProgressFunc & progFunc, size_t progInt
     if (!p->db.utxoset || !p->db.shunspent) return ret;
     auto readOpts_utxo = p->db.defReadOpts;
     auto readOpts_shunspent = p->db.defReadOpts;
-    auto [ss_utxo, ss_shunspent, bheight, bhash] = [&] {
+    const auto [ss_utxo, ss_shunspent, bheight, bhash] = [&] {
         SharedLockGuard g{p->blocksLock};
         using CSnapshot = const rocksdb::Snapshot;
         auto s1 = std::shared_ptr<CSnapshot>(p->db.utxoset->GetSnapshot(),
-                                                           [this](CSnapshot *ss){ p->db.utxoset->ReleaseSnapshot(ss); });
+                                             [this](CSnapshot *ss){ p->db.utxoset->ReleaseSnapshot(ss); });
         auto s2 = std::shared_ptr<CSnapshot>(p->db.utxoset->GetSnapshot(),
                                              [this](CSnapshot *ss){ p->db.shunspent->ReleaseSnapshot(ss); });
         const auto & [height, hash] = latestTip(); // takes a subordinate lock to blocksLock

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -241,7 +241,7 @@ public:
     };
     using UnspentItems = std::vector<UnspentItem>;
 
-    enum class TokenFilterOption { IncludeTokens, FilterTokens, OnlyTokens };
+    enum class TokenFilterOption { IncludeTokens, ExcludeTokens, OnlyTokens };
 
     /// Thread-safe. Will return an empty vector if the confirmed unspent size exceeds MaxHistory items. It may also
     /// return a truncated vector if the overflow is as a result of confirmed+unconfirmed exceeding MaxHistory.

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -233,6 +233,7 @@ public:
         IONum tx_pos = 0;
         bitcoin::Amount value;
         TxNum txNum = 0; ///< the global txNum. This + tx_pos defines the order
+        bitcoin::token::OutputDataPtr tokenDataPtr; ///< may be null, not null for outputs containing tokens
 
         // for sort & maps
         bool operator<(const UnspentItem &o) const noexcept;
@@ -240,9 +241,11 @@ public:
     };
     using UnspentItems = std::vector<UnspentItem>;
 
+    enum class TokenFilterOption { IncludeTokens, FilterTokens, OnlyTokens };
+
     /// Thread-safe. Will return an empty vector if the confirmed unspent size exceeds MaxHistory items. It may also
     /// return a truncated vector if the overflow is as a result of confirmed+unconfirmed exceeding MaxHistory.
-    UnspentItems listUnspent(const HashX &) const;
+    UnspentItems listUnspent(const HashX &, TokenFilterOption) const;
 
     /// thread safe -- returns confirmd, unconfirmed balance for a scripthash
     std::pair<bitcoin::Amount, bitcoin::Amount> getBalance(const HashX &) const;

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -248,7 +248,7 @@ public:
     UnspentItems listUnspent(const HashX &, TokenFilterOption) const;
 
     /// thread safe -- returns confirmd, unconfirmed balance for a scripthash
-    std::pair<bitcoin::Amount, bitcoin::Amount> getBalance(const HashX &) const;
+    std::pair<bitcoin::Amount, bitcoin::Amount> getBalance(const HashX &, TokenFilterOption) const;
 
     /// thread safe, called from controller when we are up-to-date
     void updateMerkleCache(unsigned height);

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -490,7 +490,7 @@ RocksDB: "utxoset"
 
 RocksDB: "scripthash_unspent"
   Key: scripthash_raw_bytes + serialized CompactTXO (40 or 41 bytes)
-  Value: 8-byte amount field (64-bit signed integer)
+  Value: 8-byte amount field (64-bit signed integer), plus optional tokenData (prefixed by 0xef)
   Comments: It turns out scanning by prefix over a table is blazingly fast in rocksdb, so we can easily do listunspent
   using this scheme. I tried a read-modify-write approach (keying off just HashX) and it was painfully slow on synch.
   This is much faster to synch.

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -317,6 +317,20 @@ public:
     /// padding.
     size_t dumpAllScriptHashes(QIODevice *outDev, unsigned indent=0, unsigned indentLevel=0, const DumpProgressFunc & = {}, size_t progInterval = 100000) const;
 
+    struct UTXOSetStats {
+        BlockHeight block_height;
+        BlockHash block_hash;
+        size_t utxo_db_ct{}, shunspent_db_ct{};
+        size_t utxo_db_size_bytes{}, shunspent_db_size_bytes{};
+        QByteArray utxo_db_shasum, shunspent_db_shasum; // sha256d sum of all key/value pairs in both dbs
+    };
+    /// Thread-safe. Call this from any thread, but ideally call it from a threadPool worker thread, since it may take
+    /// a while. Will iterate over the entire utxoset db and scripthash_unspent db and return some stats. Used by
+    /// the /debug HTTP endpoint.
+    UTXOSetStats calcUTXOSetStats(const DumpProgressFunc & = {}, size_t progInterval = 100000) const;
+
+    // --- Initial synch support ---
+
     /// Leverages RAII to have the Storage class auto-notified when initial sync has started & ended.
     class InitialSyncRAII {
         QPointer<Storage> storage;

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -439,6 +439,7 @@ private:
     void loadCheckTxNumsFileAndBlkInfo(); ///< may throw -- called from startup()
     void loadCheckTxHash2TxNumMgr(); ///< may throw -- called from startup()
     void loadCheckEarliestUndo(); ///< may throw -- called from startup()
+    void checkUpgradeDBVersion(); ///< may throw -- called from startup() as the last thing
 
     std::optional<Header> headerForHeight_nolock(BlockHeight height, QString *errMsg = nullptr) const;
     std::vector<Header> headersFromHeight_nolock_nocheck(BlockHeight height, unsigned count, QString *errMsg = nullptr) const;

--- a/src/TXO.h
+++ b/src/TXO.h
@@ -108,22 +108,26 @@ struct TXOInfo {
     HashX hashX; ///< the scripthash this output is sent to.  Note in most cases this can be compactified to be a shallow-copy of existing data (such that dupes point to the same underlying data in eg UTXOSet).
     std::optional<unsigned> confirmedHeight; ///< if unset, is mempool tx
     TxNum txNum = 0; ///< the globally mapped txNum (one for each TxHash). This is used to be able to delete the CompactTXO from the hashX's scripthash_unspent table
+    bitcoin::token::OutputDataPtr tokenDataPtr; ///< may be null, if not-null, output has token data on it
 
     bool isValid() const { return amount / bitcoin::Amount::satoshi() >= 0 && hashX.length() == HashLen; }
 
     /// for debug, etc
     bool operator==(const TXOInfo &o) const {
-        return     std::tie(  amount,   hashX,   confirmedHeight,   txNum)
-                == std::tie(o.amount, o.hashX, o.confirmedHeight, o.txNum);
+        return     std::tie(  amount,   hashX,   confirmedHeight,   txNum,   tokenDataPtr)
+                == std::tie(o.amount, o.hashX, o.confirmedHeight, o.txNum, o.tokenDataPtr);
     }
     bool operator!=(const TXOInfo &o) const { return !(*this == o); }
 
     QByteArray toBytes() const {
         QByteArray ret;
         if (!isValid()) return ret;
-        const auto amt_sats = amount / bitcoin::Amount::satoshi();
+        const int64_t amt_sats = amount / bitcoin::Amount::satoshi();
         const int32_t cheight = confirmedHeight.has_value() ? int(*confirmedHeight) : -1;
-        ret.resize(int(serSize()));
+        const int minSize = int(minSerSize());
+        const int rsvSize = minSize + (tokenDataPtr ? 1 + int(tokenDataPtr->EstimatedSerialSize()) : 0);
+        ret.reserve(rsvSize);
+        ret.resize(minSize);
         char *cur = ret.data();
         std::memcpy(cur, &amt_sats, sizeof(amt_sats));
         cur += sizeof(amt_sats);
@@ -132,11 +136,14 @@ struct TXOInfo {
         CompactTXO::txNumToCompactBytes(reinterpret_cast<std::byte *>(cur), txNum);
         cur += CompactTXO::compactTxNumSize(); // always 6
         std::memcpy(cur, hashX.constData(), size_t(hashX.length()));
+        // NOTE: `cur` may be invalidated below
+        BTC::SerializeTokenDataWithPrefix(ret, tokenDataPtr.get());
         return ret;
     }
-    static TXOInfo fromBytes(const QByteArray &ba) {
+    /// If pos_out is not nullptr, will not tolerate junk bytes at the end.
+    static TXOInfo fromBytes(const QByteArray &ba, int *pos_out = nullptr) {
         TXOInfo ret;
-        if (size_t(ba.length()) != serSize()) {
+        if (size_t(ba.length()) < minSerSize()) {
             return ret;
         }
         int64_t amt;
@@ -149,12 +156,22 @@ struct TXOInfo {
         ret.txNum = CompactTXO::txNumFromCompactBytes(reinterpret_cast<const std::byte *>(cur));
         cur += CompactTXO::compactTxNumSize(); // always 6
         ret.hashX = QByteArray(cur, HashLen);
+        cur += HashLen;
         ret.amount = amt * bitcoin::Amount::satoshi();
         if (cheight > -1)
             ret.confirmedHeight.emplace(unsigned(cheight));
+        try {
+            ret.tokenDataPtr = BTC::DeserializeTokenDataWithPrefix(ba, cur - ba.constData(), pos_out);
+            // TODO: delete this line
+            if (ret.tokenDataPtr) Debug() << "Deserialized token data: " << ret.tokenDataPtr->ToString(true).c_str();
+        } catch (const std::exception &e) {
+            // This should never happen. Indicate serious error.
+            Error() << "Got exception deserializing token data: " << e.what() << " (bytearray hex: " << ba.toHex() << ")";
+            ret = TXOInfo{};
+        }
         return ret;
     }
 
-    static constexpr size_t serSize() noexcept { return sizeof(int64_t) + sizeof(int32_t) + CompactTXO::compactTxNumSize() + HashLen; }
+    static constexpr size_t minSerSize() noexcept { return sizeof(int64_t) + sizeof(int32_t) + CompactTXO::compactTxNumSize() + HashLen; }
 };
 

--- a/src/bitcoin/token.h
+++ b/src/bitcoin/token.h
@@ -253,6 +253,11 @@ public:
         return Id::size() + 1 /* bitfield */ + sizeof(int64_t) /* Amount */
                 + 1 /* CompactSize */ + MAX_CONSENSUS_COMMITMENT_LENGTH;
     }
+
+    /* Below three added by Calin */
+    size_t GetSerialSize() const { return bitcoin::GetSerializeSize(*this); }
+    size_t GetDynMemUsage() const { return commitment.capacity() > commitment.static_capacity() ? commitment.capacity() : 0u; }
+    size_t GetMemSize() const { return sizeof(*this) + GetDynMemUsage(); }
 };
 
 using OutputDataPtr = HeapOptional<OutputData>;

--- a/src/robin_hood/robin_hood.h
+++ b/src/robin_hood/robin_hood.h
@@ -206,7 +206,8 @@ static Counts& counts() {
 
 // workaround missing "is_trivially_copyable" in g++ < 5.0
 // See https://stackoverflow.com/a/31798726/48181
-#if defined(__GNUC__) && __GNUC__ < 5
+/* This condition modified by Calin to prefer std::is_trivially_copyable on clang (clang is always __GNUC__ == 4) */
+#if defined(__GNUC__) && __GNUC__ < 5 && (!defined(__clang_major__) || __clang_major__ < 6)
 #    define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
 #else
 #    define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value


### PR DESCRIPTION
Various BCH-only CashToken-related changes including:

- Bumped Fulcrum version to 1.9.0
- Modified electrum protocol and bumped the electrum cash protocol version to 1.5.0
- Updates to `blockchain.*.listunspent` and `blockchain.*.get_balance` to take an optional second argument, `token_filter` to indicate whether to filter out token UTXOs or not.
- Some APIs that return UTXO data (such as `blockchain.utxo.get_info` and `blockchain.*.listunspent` now also may return a new key, `token_data`, for UTXOs with tokens on them.  This is documented here: https://electrum-cash-protocol.readthedocs.io/en/latest/protocol-basics.html#cashtoken-support
- Bumped DB version to v2, and made Fulcrum detect if it's running against an older DB after cashtokens activation, and refuse to run in that case (this test applies to BCH only).
- Since UTXO data (type `TXOInfo` in this codebase) is now variable-sized (depending on whether it has tokens on it or not), modified the undo DB table format and bumped the version to V3 (it can still read V1 or V2 data but V3 is written-out now for new blocks).
- Optimized performance of `blockchain.*.listunspent` to not do an un-needed extra lookup into the `utxoset` table -- it has all the data it needs right there from the `scruphash_unspent` table.
- Added two new RPCs:  `blockchain.headers.get_tip` to return the current blockchain tip (same result as you would get from `blockchain.headers.subscribe` but without actually subscribing to anything).
- Added `blockchain.headers.unsubscribe` to undo the effects of a previous call to `blockchain.headers.subscribe` (added for symmetry and since all the other `*.subscribe` methods already allow unsubscribing, this was the odd-man-out).
- Updated servers.json and servers_chipnet.json
- Various refactoring and nits