### PR TITLE
Add the `query` subcommand to the `FulcrumAdmin` script.

### DIFF
--- a/FulcrumAdmin
+++ b/FulcrumAdmin
@@ -13,33 +13,72 @@ ID_NEXT = random.randint(0, 262144)
 JSON = False
 EXITSTATUS = 0
 
+
 class ErrorResponse(RuntimeError):
     pass
 
+
+def make_new_request(method, params=None):
+    global ID_NEXT
+    reqid = ID_NEXT
+    ID_NEXT += 1
+    outj = {"id": reqid, "jsonrpc": "2.0", "method": method, "params": params or []}
+    return outj
+
+
+def sndrecv_json(sock, outj):
+    verb = False
+    msg = json.dumps(outj, indent=None).encode("utf8") + b'\n'
+    if verb:
+        print(f"Srv --> {msg[:2048]}")
+    sock.send(msg)
+    resp = bytearray()
+    seen_nl = False
+    while not seen_nl:
+        chunk = sock.recv(4096)
+        nl_index = chunk.find(b'\n')
+        if nl_index > -1:
+            seen_nl = True
+            chunk = chunk[:nl_index]
+        resp += chunk
+    if verb:
+        print(f"Srv <-- {resp[:2048]}")
+    j = json.loads(resp.decode("utf8").strip())
+    return j
+
+
 def send_request(method, params=None):
-    verb = False#not args.q
     with socket.create_connection((HOST, PORT), timeout=10.0) as sock:
-        def sndrecv(_id, method, params=None):
-            outj = { "id" : _id, "jsonrpc" : "2.0", "method" : method, "params": params or [] }
-            msg = json.dumps(outj, indent=None).encode("utf8") + b'\n'
-            if verb: print(f"Srv --> {msg[:2048]}")
-            sock.send(msg)
-            resp = bytearray()
-            while b'\n' not in resp:
-                resp += sock.recv(4096)
-            if verb: print(f"Srv <-- {resp[:2048]}")
-            j = json.loads(resp.decode("utf8").strip())
-            if j.get("error") or j.get("id") != _id:
-                raise ErrorResponse("Error response from Fulcrum:\n\n" + (json.dumps(j.get("error"), indent=4) or j))
-            return j.get("result")
-        global ID_NEXT
-        reqid = ID_NEXT; ID_NEXT += 1
-        return sndrecv(reqid, method, params)
+        req = make_new_request(method, params)
+        reqid = req['id']
+        j = sndrecv_json(sock, req)
+        if j.get("error") or j.get("id") != reqid:
+            raise ErrorResponse("Error response from Fulcrum:\n\n" + (json.dumps(j.get("error"), indent=4) or j))
+        return j.get("result")
+
+
+def send_request_batch(method_params_tuples):
+    batch = []
+    for method, params in method_params_tuples:
+        batch.append(make_new_request(method, params))
+    with socket.create_connection((HOST, PORT), timeout=10.0) as sock:
+        jarray = sndrecv_json(sock, batch)
+        ret = []
+        if not isinstance(jarray, (list, tuple)):
+            raise ErrorResponse("Error response from Fulcrum:\n\n" + jarray)
+        # Sort the responses with respect to the 'id' so they are in the order caller specified
+        jarray = sorted(jarray, key=lambda x: x.get('id') or -1)
+        for item in jarray:
+            if item.get("error") or 'result' not in item:
+                raise ErrorResponse("Error response from Fulcrum:\n\n" + (json.dumps(item.get("error"), indent=4)
+                                                                          or item))
+            ret.append(item["result"])
+        return ret
 
 
 def main():
     global HOST, PORT, JSON, EXITSTATUS
-    parser = argparse.ArgumentParser(prog="FulcrumAdmin.py", description="Fulcrum CLI admin tool")
+    parser = argparse.ArgumentParser(prog="FulcrumAdmin", description="Fulcrum CLI admin tool")
     parser.add_argument('-p', type=int, metavar="port", nargs=1, required=True, help=f"Specify the port for the Fulcrum admin RPC service. This is a required argument.")
     parser.add_argument('-j', action='store_true', dest="json", help=f"Print the response from the server as JSON, not as formatted text")
     parser.add_argument('-H', type=str, metavar="host", nargs='?', default=HOST, help=f"Specify the host for the Fulcrum admin RPC service. Defaults to {HOST}.")
@@ -64,6 +103,9 @@ def main():
     maxbuffer = subparsers.add_parser('maxbuffer', help="Query or set server max_buffer setting")
     maxbuffer.add_argument('bytes', metavar='bytes', type=int, nargs='?', help='The new desired max_buffer setting in bytes. Must be >= 64KB and <= 100MB. If omitted, then this script will just query the current value.')
     peers = subparsers.add_parser('peers', help="Print peering information")
+    query = subparsers.add_parser('query', help="Query for balance, UTXO, and history information for one or more addresses")
+    query.add_argument('address', metavar='address', nargs='+', help="Address to query")
+    query.add_argument('-l', metavar='limit', type=int, nargs='?', help="UTXO and history output limit")
     rmpeer = subparsers.add_parser('rmpeer', help="Remove peers by hostname suffix")
     rmpeer.add_argument('hostnames', metavar='hostname', nargs='+', help="A hostname or hostname suffix e.g. somehost.com or *some.host.com.")
     simdjson = subparsers.add_parser('simdjson', help="Get or set the server's 'simdjson' (JSON parser) setting")
@@ -91,6 +133,7 @@ def main():
     if command == 'banlist' : command = 'listbanned'
     command_params = tuple()
     response_handler = lambda r: json.dumps(r, indent = 4)  # default handler just pretty-prints the JSON
+    my_send_request = send_request
 
     if command is None:
         print("Please specify a command to run.\n")
@@ -221,8 +264,33 @@ possibly peer with this Fulcrum server, then please use the 'banpeer' command.
                     return f"Unexpected response from Fulcrum server: {r}"
             response_handler = handler
 
+    elif command == 'query':
+        if args.l is not None:
+            limit = int(args.l)
+            if limit <= 0:
+                print('query requires limit be >= 1.')
+                sys.exit(1)
+        else:
+            limit = 1 << 63
+        if not JSON:
+            response_handler = lambda r: query_address_handler(r, limit=limit)
+        command_params = args.address
+        command = 'query_address'
+
+        def send_request_override(method, params):
+            batch = []
+            if not JSON:
+                # First request is the getinfo which tells us the "coin" and "chain" we are on, which is used
+                # by the pretty formatter to output the balance as xx.xx BCH, etc.
+                batch.append(('getinfo', []))
+            for addr in params:
+                batch.append((method, [addr]))
+            return send_request_batch(batch)
+
+        my_send_request = send_request_override
+
     try:
-        print(response_handler(send_request(command, command_params)))
+        print(response_handler(my_send_request(command, command_params)))
         sys.exit(EXITSTATUS)
     except OSError as e:
         print(f"Error communicating with the admin RPC port at {HOST}:{PORT}\n\n    {e}\n")
@@ -231,6 +299,75 @@ possibly peer with this Fulcrum server, then please use the 'banpeer' command.
         print(f"{e}")
         sys.exit(1)
 
+
+def query_address_handler(response_list, limit):
+    """Reproduce electrumx output verbatim. Note that it has quirks such that the history list is indexed at 0
+    and the utxo list is indexed at 1 :( """
+    assert isinstance(response_list, (list, tuple))
+    assert isinstance(limit, int) and limit > 0
+    lines = []
+
+    coin_str = "(COIN UNITS)"
+    if response_list:
+        # Query the coin for proper units e.g. "BCH"
+        info = response_list[0]
+        if 'chain' in info and 'coin' in info:
+            response_list = response_list[1:]  # pop first item which is the getinfo reply
+            coin = info['coin']
+            chain = info['chain']
+            prefix = ''
+            lchain = chain.lower()
+            if not lchain.startswith('main'):
+                if lchain.startswith('scale') or lchain.startswith('sig'):
+                    prefix = 's'
+                elif lchain.startswith('reg'):
+                    prefix = 'r'
+                else:
+                    prefix = 't'
+            coin_str = prefix + coin
+
+    def format_coin_str(value):
+        neg = value < 0
+        sign = '-' if neg else ''
+        if neg:
+            value = -value
+        integral_part = value // int(1e8)
+        frac_part_str = f'{value % int(1e8):d}'
+        while len(frac_part_str) > 1 and frac_part_str[-1] == '0':  # Trim trailing zeroes
+            frac_part_str = frac_part_str[:-1]
+        return f'{sign}{integral_part:,d}.{frac_part_str} {coin_str}'
+
+    for r in response_list:
+        assert isinstance(r, dict)
+        assert 'address' in r and 'balance' in r and 'history' in r and 'unspent' in r
+        address = r['address']
+        lines.append(f'Address: {address}')
+        history = r['history']
+        if history:
+            for n, d in enumerate(history):
+                height = d['height']
+                tx_hash = d['tx_hash']
+                lines.append(f'History #{n:,d}: height {height:,d} tx_hash {tx_hash}')
+                if n + 1 >= limit:
+                    break
+        else:
+            lines.append("No history found")
+        utxos = r['unspent']
+        if utxos:
+            for n, d in enumerate(utxos, start=1):
+                tx_hash = d['tx_hash']
+                tx_pos = d['tx_pos']
+                height = d['height']
+                value = d['value']
+                lines.append(f'UTXO #{n:,d}: tx_hash {tx_hash} tx_pos {tx_pos:,d} height {height:,d} value {value:,d}')
+                if n >= limit:
+                    break
+        else:
+            lines.append("No UTXOs found")
+        bal = r['balance']
+        balance_value = int(bal['confirmed']) + int(bal['unconfirmed'])
+        lines.append(f'Balance: {format_coin_str(balance_value)}')
+    return '\n'.join(lines)
 
 
 def clients_handler(r):

--- a/FulcrumAdmin
+++ b/FulcrumAdmin
@@ -105,7 +105,7 @@ def main():
     peers = subparsers.add_parser('peers', help="Print peering information")
     query = subparsers.add_parser('query', help="Query for balance, UTXO, and history information for one or more addresses")
     query.add_argument('address', metavar='address', nargs='+', help="Address or hex-encoded scriptPubKey to query")
-    query.add_argument('-l', metavar='limit', type=int, nargs='?', help="UTXO and history output limit")
+    query.add_argument('-l', metavar='limit', type=int, nargs='?', default=1 << 63, help="UTXO and history output limit")
     rmpeer = subparsers.add_parser('rmpeer', help="Remove peers by hostname suffix")
     rmpeer.add_argument('hostnames', metavar='hostname', nargs='+', help="A hostname or hostname suffix e.g. somehost.com or *some.host.com.")
     simdjson = subparsers.add_parser('simdjson', help="Get or set the server's 'simdjson' (JSON parser) setting")
@@ -265,13 +265,10 @@ possibly peer with this Fulcrum server, then please use the 'banpeer' command.
             response_handler = handler
 
     elif command == 'query':
-        if args.l is not None:
-            limit = int(args.l)
-            if limit <= 0:
-                print('query requires limit be >= 1.')
-                sys.exit(1)
-        else:
-            limit = 1 << 63
+        limit = int(args.l)
+        if limit <= 0:
+            print('query requires limit be >= 1.')
+            sys.exit(1)
         if not JSON:
             response_handler = lambda r: query_address_handler(r, limit=limit)
         command_params = args.address
@@ -312,7 +309,7 @@ def query_address_handler(response_list, limit):
         # Query the coin for proper units e.g. "BCH"
         info = response_list[0]
         if 'chain' in info and 'coin' in info:
-            response_list = response_list[1:]  # pop first item which is the getinfo reply
+            del response_list[0]  # pop first item which is the getinfo reply
             coin = info['coin']
             chain = info['chain']
             prefix = ''

--- a/FulcrumAdmin
+++ b/FulcrumAdmin
@@ -104,7 +104,7 @@ def main():
     maxbuffer.add_argument('bytes', metavar='bytes', type=int, nargs='?', help='The new desired max_buffer setting in bytes. Must be >= 64KB and <= 100MB. If omitted, then this script will just query the current value.')
     peers = subparsers.add_parser('peers', help="Print peering information")
     query = subparsers.add_parser('query', help="Query for balance, UTXO, and history information for one or more addresses")
-    query.add_argument('address', metavar='address', nargs='+', help="Address to query")
+    query.add_argument('address', metavar='address', nargs='+', help="Address or hex-encoded scriptPubKey to query")
     query.add_argument('-l', metavar='limit', type=int, nargs='?', help="UTXO and history output limit")
     rmpeer = subparsers.add_parser('rmpeer', help="Remove peers by hostname suffix")
     rmpeer.add_argument('hostnames', metavar='hostname', nargs='+', help="A hostname or hostname suffix e.g. somehost.com or *some.host.com.")
@@ -339,9 +339,13 @@ def query_address_handler(response_list, limit):
 
     for r in response_list:
         assert isinstance(r, dict)
-        assert 'address' in r and 'balance' in r and 'history' in r and 'unspent' in r
-        address = r['address']
-        lines.append(f'Address: {address}')
+        assert ('address' in r or 'script' in r) and 'balance' in r and 'history' in r and 'unspent' in r
+        if 'address' in r:
+            address = r['address']
+            lines.append(f'Address: {address}')
+        elif 'script' in r:
+            script_hex = r['script']
+            lines.append(f"Script: {script_hex}")
         history = r['history']
         if history:
             for n, d in enumerate(history):

--- a/src/BTC.h
+++ b/src/BTC.h
@@ -187,9 +187,8 @@ namespace BTC
         return cs.size() > 0 && *cs.begin() == bitcoin::opcodetype::OP_RETURN;
     }
 
-    inline QByteArray HashXFromCScript(const bitcoin::CScript &cs) {
-        return QByteArray(BTC::HashRev(QByteArray::fromRawData(reinterpret_cast<const char *>(cs.data()), int(cs.size())), true));
-    }
+    inline QByteArray HashXFromByteView(const ByteView &bv) { return BTC::HashRev(bv.toByteArray(false), true); }
+    inline QByteArray HashXFromCScript(const bitcoin::CScript &cs) { return HashXFromByteView(cs); }
 
     /// Header Chain Verifier -
     /// To use: Basically keep calling operator() on it with subsequent headers and it will make sure

--- a/src/ByteView.h
+++ b/src/ByteView.h
@@ -86,8 +86,8 @@ public:
     std::string_view toStringView() const noexcept { return std::string_view{charData(), size()}; }
 
     QByteArray toByteArray(bool deepCopy = true) const {
-        return deepCopy ? QByteArray{charData(), int(size())}
-                        : QByteArray::fromRawData(charData(), int(size()));
+        return deepCopy ? QByteArray{charData(), QByteArray::size_type(size())}
+                        : QByteArray::fromRawData(charData(), QByteArray::size_type(size()));
     }
 
     /// Convenience: reimplements super class, but in this case to return a ByteView

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -1473,6 +1473,7 @@ void Server::rpc_blockchain_address_get_balance(Client *c, const RPC::BatchId ba
     const auto tf = parseTokenFilterOptionCommon(c, m, 1);
     impl_get_balance(c, batchId, m, sh, tf);
 }
+
 QVariantMap ServerBase::getBalanceCommon(const HashX &sh, Storage::TokenFilterOption tokenFilter)
 {
     const auto [amt, uamt] = storage->getBalance(sh, tokenFilter);
@@ -1484,8 +1485,8 @@ QVariantMap ServerBase::getBalanceCommon(const HashX &sh, Storage::TokenFilterOp
         { "unconfirmed" , qlonglong(uamt / uamt.satoshi()) },
     };
     return resp;
-
 }
+
 void Server::impl_get_balance(Client *c, const RPC::BatchId batchId, const RPC::Message &m, const HashX &sh,
                               const Storage::TokenFilterOption tokenFilter)
 {

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -847,8 +847,21 @@ void ServerBase::generic_async_to_bitcoind(Client *c, const RPC::BatchId batchId
             c->bdReqCtr -= std::min(c->bdReqCtr, 1LL); // decrease throttle counter
             --c->perIPData->bdReqCtr; // decrease bitcoind request counter (per-IP, owned by multiple threads)
             try {
-                const QVariant result = successFunc ? successFunc(reply) : reply.result(); // if no successFunc specified, use default which just copies the result to the client.
-                emit c->sendResult(batchId, reqId, result);
+                QVariant result;
+                bool send = true;
+                if (!successFunc)
+                    // if no successFunc specified, use default which just copies the result to the client.
+                    result = reply.result();
+                else {
+                    const auto res = successFunc(reply);
+                    std::visit(Overloaded {
+                        // successFunct() returned a valid QVariant, so we auto-send a reply to the client
+                        [&](const QVariant &var) { result = var; },
+                        // successFunc() specified to not auto-send a reply to client (it will handle the reply itself)
+                        [&](const DontAutoSendReply_t &) { send = false; }
+                    }, res);
+                }
+                if (send) emit c->sendResult(batchId, reqId, result);
             } catch (const RPCError &e) {
                 emit c->sendError(e.disconnect, e.code, e.what(), batchId, reqId);
             } catch (const std::exception &e) {
@@ -1460,25 +1473,30 @@ void Server::rpc_blockchain_address_get_balance(Client *c, const RPC::BatchId ba
     const auto tf = parseTokenFilterOptionCommon(c, m, 1);
     impl_get_balance(c, batchId, m, sh, tf);
 }
+QVariantMap ServerBase::getBalanceCommon(const HashX &sh, Storage::TokenFilterOption tokenFilter)
+{
+    const auto [amt, uamt] = storage->getBalance(sh, tokenFilter);
+    /* Note: ElectrumX protocol docs are incorrect. They claim a string in coin units is returned here.
+     * It is not. Instead a number in satoshis is returned!
+     * Incorrect docs: https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-balance */
+    QVariantMap resp{
+        { "confirmed" , qlonglong(amt / amt.satoshi()) },
+        { "unconfirmed" , qlonglong(uamt / uamt.satoshi()) },
+    };
+    return resp;
+
+}
 void Server::impl_get_balance(Client *c, const RPC::BatchId batchId, const RPC::Message &m, const HashX &sh,
                               const Storage::TokenFilterOption tokenFilter)
 {
     generic_do_async(c, batchId, m.id, [sh, tokenFilter, this] {
-        const auto [amt, uamt] = storage->getBalance(sh, tokenFilter);
-        /* Note: ElectrumX protocol docs are incorrect. They claim a string in coin units is returned here.
-         * It is not. Instead a number in satoshis is returned!
-         * Incorrect docs: https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-balance */
-        QVariantMap resp{
-          { "confirmed" , qlonglong(amt / amt.satoshi()) },
-          { "unconfirmed" , qlonglong(uamt / uamt.satoshi()) },
-        };
-        return resp;
+        return getBalanceCommon(sh, tokenFilter);
     });
 }
 
 /// called from get_mempool and get_history to retrieve the mempool for a hashx synchronously.  Returns the
 /// QVariantMap suitable for placing into the resulting response.
-QVariantList Server::getHistoryCommon(const HashX &sh, bool mempoolOnly)
+QVariantList ServerBase::getHistoryCommon(const HashX &sh, bool mempoolOnly)
 {
     QVariantList resp;
     const auto items = storage->getHistory(sh, !mempoolOnly, true); // these are already sorted
@@ -1545,7 +1563,7 @@ void Server::rpc_blockchain_address_listunspent(Client *c, const RPC::BatchId ba
     impl_listunspent(c, batchId, m, sh, tf);
 }
 /* static */
-QVariantMap Server::unspentItemToVariantMap(const Storage::UnspentItem & item)
+QVariantMap ServerBase::unspentItemToVariantMap(const Storage::UnspentItem & item)
 {
     QVariantMap vm{
         { QByteArrayLiteral("tx_hash") , Util::ToHexFast(item.hash) },
@@ -1557,16 +1575,20 @@ QVariantMap Server::unspentItemToVariantMap(const Storage::UnspentItem & item)
         vm.insert(QByteArrayLiteral("token_data"), tokenDataToVariantMap(*item.tokenDataPtr));
     return vm;
 }
+QVariantList  ServerBase::listUnspentCommon(const HashX &sh, Storage::TokenFilterOption tokenFilter)
+{
+    QVariantList resp;
+    const auto items = storage->listUnspent(sh, tokenFilter); // these are already sorted
+    resp.reserve(items.size());
+    for (const auto & item : items)
+        resp.push_back(unspentItemToVariantMap(item));
+    return resp;
+}
 void Server::impl_listunspent(Client *c, const RPC::BatchId batchId, const RPC::Message &m, const HashX &sh,
                               const Storage::TokenFilterOption tokenFilter)
 {
     generic_do_async(c, batchId, m.id, [sh, tokenFilter, this] {
-        QVariantList resp;
-        const auto items = storage->listUnspent(sh, tokenFilter); // these are already sorted
-        resp.reserve(items.size());
-        for (const auto & item : items)
-            resp.push_back(unspentItemToVariantMap(item));
-        return resp;
+        return listUnspentCommon(sh, tokenFilter);
     });
 }
 void Server::rpc_blockchain_scripthash_subscribe(Client *c, const RPC::BatchId batchId, const RPC::Message &m)
@@ -2638,6 +2660,39 @@ void AdminServer::rpc_peers(Client *c, const RPC::BatchId batchId, const RPC::Me
         return peerMgr->statsSafe(kBlockingCallTimeoutMS);
     });
 }
+void AdminServer::rpc_query_address(Client *c, const RPC::BatchId batchId, const RPC::Message &m)
+{
+    const auto l = m.paramsList();
+    assert(l.size() == 1);
+    // Step 1: Rely on the bitcoin daemon to parse the address (so we don't have to)
+    generic_async_to_bitcoind(c, batchId, m.id, "validateaddress", l,
+                              [this, c, batchId, reqId = m.id, param = l.front().toString()](const RPC::Message &reply){
+        const QVariantMap resp = reply.result().toMap();
+        if (!resp.value("isvalid", false).toBool())
+            throw RPCError(QString("Invalid address: %1").arg(param), RPC::Code_InvalidParams);
+        QString address;
+        QByteArray scriptPubKey;
+        if ((address = resp.value("address").toString()).isEmpty()
+            || (scriptPubKey = Util::ParseHexFast(resp.value("scriptPubKey").toString().toLatin1(), true)).isEmpty()) {
+            throw RPCError(QString("Unexpected response from remote daemon"), RPC::Code_InternalError);
+        }
+
+        // Step 2: After we got the scriptPubKey from the daemon, use it to get a hashX and the balance, history, etc
+        generic_do_async(c, batchId, reqId, [this, address, hashX = BTC::HashXFromByteView(scriptPubKey)]{
+            QVariantMap reply;
+
+            reply["address"] = address;
+            reply["history"] = getHistoryCommon(hashX, false);
+            reply["unspent"] = listUnspentCommon(hashX, Storage::TokenFilterOption::IncludeTokens);
+            reply["balance"] = getBalanceCommon(hashX, Storage::TokenFilterOption::IncludeTokens);
+
+            return reply;
+        });
+
+        // we don't auto-send any reply to client because we do more asynch stuff above
+        return DontAutoSendReply;
+    });
+}
 void AdminServer::rpc_rmpeer(Client *c, const RPC::BatchId batchId, const RPC::Message &m)
 {
     if (peerMgr.expired())
@@ -2719,6 +2774,7 @@ HEY_COMPILER_PUT_STATIC_HERE(AdminServer::StaticData::registry){
     { {"loglevel",                          true,               false,    PR{1,1},                 {} },          MP(rpc_loglevel) },
     { {"maxbuffer",                         true,               false,    PR{0,1},                 {} },          MP(rpc_maxbuffer) },
     { {"peers",                             true,               false,    PR{0,0},                 {} },          MP(rpc_peers) },
+    { {"query_address",                     true,               false,    PR{1,1},                 {} },          MP(rpc_query_address) },
     { {"rmpeer",                            true,               false,    PR{1,UNLIMITED},         {} },          MP(rpc_rmpeer) },
     { {"shutdown",                          true,               false,    PR{0,0},                 {} },          MP(rpc_shutdown) },
     { {"simdjson",                          true,               false,    PR{0,1},                 {} },          MP(rpc_simdjson) },

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -58,6 +58,7 @@
 
 #include <QRegularExpression>
 
+#include <cctype>
 #include <cstring>             // for strerror
 #include <iostream>
 #include <mutex>
@@ -268,6 +269,12 @@ namespace Util {
         }
         return true;
     }
+
+    bool IsValidHex(const QByteArray &s)
+    {
+        return s.size() % 2 == 0 && std::all_of(s.begin(), s.end(), [](char const c) { return std::isxdigit(c); });
+    }
+
 
     namespace {
         /// Stores a hash seed that we will use for our hash tables.

--- a/src/Util.h
+++ b/src/Util.h
@@ -1092,6 +1092,6 @@ public:
     void store(T && o) { lockExclusively().first = std::move(o); }
 };
 
-// helper type for std::visit (currently unused in this code base due to lack of std::variant support)
+// helper type for std::visit
 template<class... Ts> struct Overloaded : Ts... { using Ts::operator()...; };
 template<class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;

--- a/src/Util.h
+++ b/src/Util.h
@@ -601,6 +601,11 @@ namespace Util {
     /// 2x the length of bytes.  `buf` must not overlap with `bytes`.
     bool ToHexFastInPlace(const QByteArray & bytes, char *buf, size_t bufsz);
 
+    /// Returns true iff:
+    /// - all chars in the string are in the set: 0123456789abcdefABCDEF
+    /// - the string has an even number of characters (or is empty)
+    bool IsValidHex(const QByteArray &maybeHexStr);
+
     /// For each item in a QByteArray Container, hex encode each item using Util::ToHexFast().
     template <typename Container,
               std::enable_if_t<std::is_base_of_v<QByteArray, typename Container::value_type>, int> = 0>


### PR DESCRIPTION
This closes #165.  It allows the user to use a new `query` verb with `FulcrumAdmin`, similar to how it works on [elextrumx_rpc](https://github.com/spesmilo/electrumx/blob/master/electrumx_rpc#L56).

Usage:

```bash
calin@Box ~/Fulcrum/ $ ./FulcrumAdmin query -h
usage: FulcrumAdmin query [-h] [-l [limit]] address [address ...]

positional arguments:
  address     Address or hex-encoded scriptPubKey to query

optional arguments:
  -h, --help  show this help message and exit
  -l [limit]  UTXO and history output limit
```

Example run with a mix of legacy, cashaddr, and scriptPubKey hex as input:

```bash
calin@Box ~/Fulcrum/ $ ./FulcrumAdmin -p 9000 query -l 5 mgSyDui1gE4f7NKs1CcrnhpYt4fuN6HSZU qr7k35kg0uxuz7v729jh6vh0hx4rvlgkrc8pq96ndx bchtest:qr4gww42l0wh5lr56ulwz96wgtmzpv9p3sz4wxrydq bchtest:qq3pfyjzgjhske7jlfpslypq8skys0d4zgc70ahmcq 76a9147dbdcf6c874cba69392bd319a285ac100e7fc15f88ac
Address: bchtest:qq9rw090p2eu9drv6ptztwx4ghpftwfa0gyqvlvx2q
History #0: height 30 tx_hash e69c9b4b32a4b0a95edbc3f5f907f143a74332772ed46915d6fd7760d26cf54a
History #1: height 31 tx_hash ccd41a9d358b224413c5a8d835a83e75e076d26ba0681b815ef0fd6a2d860c4e
History #2: height 32 tx_hash 8a43966006b97c6b2cbc914384f371e89c15d26031f0f36e883df62b7b4e0c28
History #3: height 33 tx_hash a781d7b3ff23e63dfbfff9997c3d6d0058777b6d8b798d05fa3d541235782a2b
History #4: height 34 tx_hash 9feb6f0d1213ecf360ed2b535e7e4d2e469a3e53e538e7032baf57ea69e228b5
UTXO #1: tx_hash 52e5cbcb7ff94f0832a7c731506b953eebcfc049e9680d563075acdcbcf386d2 tx_pos 0 height 55,885 value 5,000,000,000
UTXO #2: tx_hash 6eb228f0838d3d859e104a5051e6b7f38b1c2f028fd2d74e8b1e096e67ba424a tx_pos 0 height 55,886 value 5,000,000,000
UTXO #3: tx_hash b34d53e71cf1b42dbb8e5bb7496b481f540447a05c88b20f2406bfa2d03d65f3 tx_pos 0 height 55,887 value 5,000,000,000
UTXO #4: tx_hash 9897fcbaf542ee151f18348fc9c2a7602438dbb47646c0ff4944c5dc17dbfd23 tx_pos 0 height 55,888 value 5,000,000,000
UTXO #5: tx_hash 1fa7e514e8c0c52caffa8d955d936cadd5d5957c0c136d590e599b5512b539f7 tx_pos 0 height 55,889 value 5,000,000,000
Balance: 750.7671 tBCH
Address: bchtest:qr7k35kg0uxuz7v729jh6vh0hx4rvlgkrc8pq96ndx
History #0: height 108,234 tx_hash 9d4842ede0db89a36504fa8a100e6430362c36b84ce57a23f92e6299bb4cfc53
History #1: height 109,245 tx_hash 80101f17039368630cf7dc2d1cda1c5d52aac4fbe2dd37f0a776ef92c23e3993
History #2: height 140,065 tx_hash 1ca29a27d955666e3dc41fdf9f2fecb99630caeb2440001076cbd18577a43174
UTXO #1: tx_hash 1ca29a27d955666e3dc41fdf9f2fecb99630caeb2440001076cbd18577a43174 tx_pos 0 height 140,065 value 8,260,688,715,176
Balance: 82,606.88715176 tBCH
Address: bchtest:qr4gww42l0wh5lr56ulwz96wgtmzpv9p3sz4wxrydq
History #0: height 130,356 tx_hash 60a8885ad94471166b9333f36acdcb404babca883db439b34329b506c328f519
UTXO #1: tx_hash 60a8885ad94471166b9333f36acdcb404babca883db439b34329b506c328f519 tx_pos 1 height 130,356 value 4,899,999,500
Balance: 48.999995 tBCH
Address: bchtest:qq3pfyjzgjhske7jlfpslypq8skys0d4zgc70ahmcq
No history found
No UTXOs found
Balance: 0.0 tBCH
Script: 76a9147dbdcf6c874cba69392bd319a285ac100e7fc15f88ac
History #0: height 130,789 tx_hash dd533368cbf56582374b5b5e33b0160287df6a3c9e84e744a85ce9cb6624844f
History #1: height 142,537 tx_hash 66c6334805d1e1988ee7e43ab634bb6095169ead659645d4fccd851261c2faa9
UTXO #1: tx_hash 66c6334805d1e1988ee7e43ab634bb6095169ead659645d4fccd851261c2faa9 tx_pos 0 height 142,537 value 59,998,715
Balance: 0.59998715 tBCH
```