### PR TITLE
Refactor: Use std::variant in more places in the codebase + add some unit tests

### DIFF
--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -67,13 +67,11 @@ namespace RPC {
         ret.v1 = v1;
         ret.data = map;
 
-        if (id_out)
-            id_out->clear();
+        if (id_out) id_out->setNull();
 
         try {
             ret.id = Id::fromVariant(map.value(s_id));
-            if (id_out)
-                *id_out = ret.id;
+            if (id_out) *id_out = ret.id;
         } catch (const BadArgs & e) {
             throw InvalidError(QString("Error parsing JSON key \"%1\": %2").arg(s_id, e.what()));
         }

--- a/src/RPC.h
+++ b/src/RPC.h
@@ -110,7 +110,7 @@ namespace RPC {
 
         // -- DATA --
 
-        Id id; ///< guaranteed to be either string, qint64, or null
+        Id id; ///< guaranteed to be either string, int64_t, or null
         QString method; /**< methodName extracted from data['method'] if it was present. If this is empty then no
                              'method' key was present in JSON. May also contain the "matched" method on a response
                              object where we matched the id to a method we knew about in Connection::idMethodMap. */

--- a/src/RPCMsgId.cpp
+++ b/src/RPCMsgId.cpp
@@ -94,3 +94,151 @@ QString RPCMsgId::toString() const
                           [](const int64_t i) { return QString::number(qint64(i)); }
                       }, var);
 }
+
+#ifdef ENABLE_TESTS
+#include "App.h"
+
+#include <unordered_set>
+
+namespace {
+    using Print = Log;
+
+    bool doTest()
+    {
+        size_t ctr = 0;
+        const Tic t0;
+#undef STR
+#undef CHK
+#define STR(x) #x
+#define CHK(x) \
+        do { \
+                ++ctr; \
+                if ( ! (x) ) { \
+                    Error() << "Test: \"" << STR(x) << "\" failed!"; \
+                    return false; \
+            } else { \
+                    Print() << "Test: \"" << STR(x) << "\"" << " passed"; \
+            } \
+        } while(0)
+#define CHKEXC(x, exc) \
+        do { \
+            try { \
+                (x); \
+            } catch (const exc &) { \
+                ++ctr; \
+                Print() << "Test \"" << STR(x) << "\" throws \"" << STR(exc) << "\" passed"; \
+            } catch (...) {\
+                Error() << "Test: \"" << STR(x) << "\" throws \"" << STR(exc) << "\" failed!"; \
+                return false; \
+            } \
+        } while (0)
+
+        CHK(RPCMsgId().isNull());
+        CHK(!RPCMsgId(123).isNull());
+        CHK(!RPCMsgId("hello").isNull());
+
+        RPCMsgId r;
+        CHK(r.isNull());
+        CHK(RPCMsgId() == r);
+        r = RPCMsgId::fromVariant(QVariant{123});
+        CHK(RPCMsgId() != r);
+        CHK(!r.isNull());
+        RPCMsgId r2 = r;
+        CHK(r == r2);
+        r2.setNull();
+        CHK(r2.isNull());
+        CHK(r2 != r);
+        CHK(RPCMsgId{} == r2);
+        CHK(RPCMsgId{} < r);
+        CHK(r.toInt() == 123);
+        CHK(r2.toInt() == 0);
+        CHK(r.toString() == "123");
+        CHK(r2.toString() == "null");
+        CHK(r < RPCMsgId::fromVariant(QVariant(124)));
+        CHK(r != RPCMsgId::fromVariant(QVariant(124)));
+        CHK(RPCMsgId::fromVariant(QVariant(124)) > r);
+        CHK(RPCMsgId::fromVariant(QVariant(124)) < RPCMsgId::fromVariant(QVariant(125)));
+        CHK(r != RPCMsgId("123"));
+        CHK(RPCMsgId("123").toInt() == 123);
+        CHK(RPCMsgId("123").toString() == "123");
+        CHK(r < RPCMsgId("123"));
+        CHK(r != RPCMsgId::fromVariant("123"));
+        CHK(r == RPCMsgId::fromVariant(123.0));
+        CHKEXC(RPCMsgId::fromVariant(123.01), BadArgs);
+        CHKEXC(RPCMsgId::fromVariant(2.000000000000001), BadArgs);
+        CHK(RPCMsgId::fromVariant("2.000000000000001").toString() == "2.000000000000001");
+        CHK(RPCMsgId::fromVariant(2.0000000000000001) == RPCMsgId{2}); // impl. quirk: if the fractional part is too small, we map to integer :/
+        CHK(RPCMsgId::fromVariant("2.0000000000000001") != RPCMsgId{2});
+        CHK(RPCMsgId::fromVariant("2.0000000000000001").toString() ==  "2.0000000000000001");
+        CHK(Compat::GetVarType(r.toVariant()) == QMetaType::LongLong);
+        CHK(Compat::GetVarType(RPCMsgId::fromVariant("123").toVariant()) == QMetaType::QString);
+        CHK(Compat::GetVarType(RPCMsgId::fromVariant(123.0).toVariant()) == QMetaType::LongLong);
+        CHK(RPCMsgId::fromVariant(QVariant{}).toVariant().isNull());
+        CHK(r.toVariant() == QVariant(123));
+        CHK(r.toVariant() == QVariant(123.0));
+        CHK(r.toVariant() != QVariant("123.0"));
+        CHK(r.toVariant() == QVariant("123"));
+
+        // operator=, .isint(), .isString(), .isNull()
+        r.setNull();
+        CHK(r.isNull());
+        CHK(!r.isString());
+        CHK(!r.isInt());
+        r = "foo";
+        CHK(!r.isNull());
+        CHK(r.isString());
+        CHK(!r.isInt());
+        CHK(r.toString() == "foo");
+        CHK(r.toInt() == 0);
+        CHK(RPCMsgId("foo") == r);
+        r.setNull();
+        CHK(r.isNull());
+        r = 999;
+        CHK(!r.isNull());
+        CHK(!r.isString());
+        CHK(r.isInt());
+        CHK(r.toString() == "999");
+        CHK(r.toInt() == 999);
+        CHK(RPCMsgId(999) == r);
+        CHK(RPCMsgId("999") != r);
+
+        std::unordered_set<RPCMsgId> s;
+
+        s.emplace("hello");
+        s.emplace("1");
+        s.emplace("1.2");
+        s.emplace("2");
+        CHKEXC(s.emplace(RPCMsgId::fromVariant(1.2)), BadArgs);
+        s.emplace(1);
+        s.emplace(2);
+        s.emplace();
+
+        CHK(s.size() == 7);
+        CHK(s.emplace(RPCMsgId::fromVariant(QVariant{})).second == false);
+        CHK(s.size() == 7);
+
+        QSet<RPCMsgId> qs;
+        qs.insert(QString{"hello"});
+        qs.insert(QString{"1"});
+        qs.insert(QString{"1.2"});
+        qs.insert(QString{"2"});
+        CHKEXC(qs.insert(RPCMsgId::fromVariant(1.2)), BadArgs);
+        qs.insert(1);
+        qs.insert(2);
+        qs.insert(RPCMsgId{});
+
+        CHK(qs.size() == 7);
+        CHK(qs.contains(RPCMsgId::fromVariant(QVariant{})));
+
+        Print() << "rpcmsgid passed " << ctr << " checks ok in " << t0.msecStr() << " msecs";
+        return true;
+#undef STR
+#undef CHK
+    }
+
+    const auto t = App::registerTest("rpcmsgid", []{
+        if (!doTest()) throw Exception("rpcmsgid test failed");
+    });
+} // namespace
+
+#endif

--- a/src/RPCMsgId.h
+++ b/src/RPCMsgId.h
@@ -25,6 +25,7 @@
 #include <QVariant>
 
 #include <cstdint>
+#include <functional> // for std::hash
 #include <utility>
 #include <variant>
 

--- a/src/RPCMsgId.h
+++ b/src/RPCMsgId.h
@@ -49,7 +49,10 @@ public:
     RPCMsgId(RPCMsgId &&) = default;
 
     bool isNull() const { return std::holds_alternative<Null>(var); }
-    void setNull() { var = Null{}; }
+    void setNull() { var.emplace<Null>(); }
+
+    bool isInt() const { return std::holds_alternative<int64_t>(var); }
+    bool isString() const { return std::holds_alternative<QString>(var); }
 
     bool operator<(const RPCMsgId & o) const { return var < o.var; }
     bool operator>(const RPCMsgId & o) const { return var > o.var; }
@@ -73,8 +76,8 @@ public:
     static RPCMsgId fromVariant(const QVariant &) noexcept(false);
 
     // getters
-    int64_t toInt() const; // returns the value if type() == Integer, or tries to parse the value if String, or returns 0 if cannot parse or Null
-    QString toString() const; // returns the string value (may return a number string if type() == Integer or 'null' if type() == Null
+    int64_t toInt() const; // returns the value if it was an integer, or tries to parse the value if QString, or returns 0 if cannot parse or Null
+    QString toString() const; // returns the string value (may return a number string if we have an integer, or 'null' if .isNull())
 };
 
 /// template specialization for std::hash of RPCMsgId (for std::unordered_map, std::unordered_set, etc)

--- a/src/SubStatus.cpp
+++ b/src/SubStatus.cpp
@@ -27,8 +27,153 @@ QVariant SubStatus::toVariant() const
             ret = Util::ToHexFast(*ba);
         else if (auto *dsp = dsproof(); dsp && !dsp->isEmpty())
             ret = dsp->toVarMap();
-        else if (auto *bh = blockHeight(); bh && *bh)
-            ret = **bh; // ptr -> optional -> value
+        else if (auto bh = blockHeight(); bh)
+            ret = *bh; // optional -> value
     }
     return ret;
 }
+
+#ifdef ENABLE_TESTS
+#include "App.h"
+#include "Common.h"
+#include "Util.h"
+
+namespace {
+    using Print = Log;
+
+    bool doTest()
+    {
+        size_t ctr = 0;
+        const Tic t0;
+#undef STR
+#undef CHK
+#define STR(x) #x
+#define CHK(x) \
+    do { \
+        ++ctr; \
+        if ( ! (x) ) { \
+            Error() << "Test: \"" << STR(x) << "\" failed!"; \
+            return false; \
+        } else { \
+            Print() << "Test: \"" << STR(x) << "\"" << " passed"; \
+        } \
+    } while(0)
+
+    CHK(!SubStatus().has_value());
+    CHK(SubStatus(QByteArray{}).has_value());
+    CHK(SubStatus(DSProof{}).has_value());
+    CHK(SubStatus(std::nullopt).has_value());
+    CHK(!SubStatus(std::nullopt).blockHeight().has_value());
+    CHK(SubStatus(BlockHeight{1}).blockHeight().has_value());
+    CHK(SubStatus(BlockHeight{1}).blockHeight().value_or(0) == 1);
+    CHK(SubStatus(std::nullopt).has_value());
+    CHK(!SubStatus(std::nullopt).blockHeight().has_value());
+    CHK(SubStatus(BlockHeight{1}).blockHeight().has_value());
+    CHK(SubStatus(BlockHeight{1}).blockHeight().value_or(0) == 1);
+
+    CHK(SubStatus{}.byteArray() == nullptr);
+    CHK(SubStatus(QByteArray{}).byteArray() != nullptr);
+    CHK(SubStatus(DSProof{}).byteArray() == nullptr);
+    CHK(SubStatus(BlockHeight{}).byteArray() == nullptr);
+
+    CHK(SubStatus{}.dsproof() == nullptr);
+    CHK(SubStatus(QByteArray{}).dsproof() == nullptr);
+    CHK(SubStatus(DSProof{}).dsproof() != nullptr);
+    CHK(SubStatus(BlockHeight{}).dsproof() == nullptr);
+
+    CHK(SubStatus{}.blockHeight() == std::nullopt);
+    CHK(SubStatus(QByteArray{}).blockHeight() == std::nullopt);
+    CHK(SubStatus(DSProof{}).blockHeight() == std::nullopt);
+    CHK(SubStatus(BlockHeight{}).blockHeight() != std::nullopt);
+
+    SubStatus null;
+    SubStatus qb{QByteArray(32, 'c')};
+    SubStatus ds{DSProof{DspHash(), QByteArray{128, 'e'}, TXO{TxHash{32, 'a'}, 1}, TxHash{32, 'f'}, {}}};
+    SubStatus bh{12345};
+    SubStatus tmp;
+
+    CHK(bh != SubStatus{12346});
+    CHK(!(SubStatus{12346} == bh));
+    CHK(bh == SubStatus{12345});
+    CHK(ds.dsproof() && !ds.dsproof()->isEmpty());
+    CHK(ds != DSProof{});
+    const DSProof ds2{DspHash(), QByteArray{128, 'e'}, TXO{TxHash{32, 'a'}, 1}, TxHash{32, 'f'}, {}};
+    const DSProof ds3{DspHash(), QByteArray{128, 'z'}, TXO{TxHash{32, 'a'}, 1}, TxHash{32, 'f'}, {}};
+    CHK(ds == ds2);
+    CHK(ds != ds3);
+    CHK(bh != ds2);
+    CHK(ds != std::optional<BlockHeight>(12345));
+    CHK(bh == std::optional<BlockHeight>(12345));
+    CHK(bh != std::optional<BlockHeight>(12346));
+    CHK(qb == QByteArray(32, 'c'));
+    CHK(qb != QByteArray(32, '!'));
+
+    CHK(tmp == null);
+    CHK(!tmp.has_value());
+    CHK(tmp != qb);
+    CHK(tmp != ds);
+    CHK(tmp != bh);
+    CHK(!tmp.byteArray());
+    CHK(!tmp.dsproof());
+    CHK(!tmp.blockHeight().has_value());
+
+    tmp = qb;
+    CHK(tmp.has_value());
+    CHK(tmp != null);
+    CHK(tmp == qb);
+    CHK(tmp != ds);
+    CHK(tmp != bh);
+    CHK(tmp.byteArray());
+    CHK(!tmp.dsproof());
+    CHK(!tmp.blockHeight().has_value());
+    tmp.reset();
+    CHK(!tmp.has_value());
+    CHK(tmp == null);
+
+    tmp = ds;
+    CHK(tmp.has_value());
+    CHK(tmp != null);
+    CHK(tmp != qb);
+    CHK(tmp == ds);
+    CHK(tmp != bh);
+    tmp.reset();
+    CHK(!tmp.has_value());
+    CHK(tmp == null);
+
+    tmp = bh;
+    CHK(tmp.has_value());
+    CHK(tmp != null);
+    CHK(tmp != qb);
+    CHK(tmp != ds);
+    CHK(tmp == bh);
+    tmp.reset();
+    CHK(!tmp.has_value());
+    CHK(tmp == null);
+
+    auto oqb = qb;
+    tmp = std::move(qb);
+    CHK(tmp == oqb && tmp.byteArray() != nullptr);
+
+    auto ods = ds;
+    tmp = std::move(ds);
+    CHK(tmp == ods && tmp.dsproof() != nullptr);
+
+    auto obh = bh;
+    tmp = std::move(bh);
+    CHK(tmp == obh && tmp.blockHeight() != std::nullopt);
+
+    tmp = SubStatus{};
+    CHK(tmp == null && !tmp.has_value() && !tmp.blockHeight() && !tmp.byteArray() && !tmp.dsproof());
+
+    Print() << "substatus passed " << ctr << " checks ok in " << t0.msecStr() << " msecs";
+    return true;
+#undef STR
+#undef CHK
+    }
+
+    const auto t = App::registerTest("substatus", []{
+        if (!doTest()) throw Exception("substatus test failed");
+    });
+} // namespace
+
+#endif

--- a/src/SubStatus.h
+++ b/src/SubStatus.h
@@ -26,6 +26,7 @@
 #include <QVariant>
 
 #include <cstdint>
+#include <functional> // for std::hash
 #include <limits>
 #include <memory>
 #include <optional>

--- a/src/SubsMgr.cpp
+++ b/src/SubsMgr.cpp
@@ -495,7 +495,7 @@ inline QByteArray optimizedStatusHashCalc(const Storage::History &hist) {
     // status is non-reversed, single sha256 (32 bytes)
     return ret;
 }
-}
+} // namespace
 
 auto ScriptHashSubsMgr::getFullStatus(const HashX &sh) const -> SubStatus
 {

--- a/src/SubsMgr.h
+++ b/src/SubsMgr.h
@@ -309,9 +309,9 @@ protected:
 public:
     ~TransactionSubsMgr() override;
 
-    /// Thread-safe. Returns a SubStatus object which .has_value() and where .blockHeight() is not nullptr.
-    /// Will return an object with a *blockHeight() which is itself nullopt (default constructed) if the tx in question
-    /// is not known. Otherwise the **blockHeight() will be a height where 0=mempool and >0=confirmed_height.
+    /// Thread-safe. Returns a SubStatus object which .has_value().
+    /// Will return an object with a blockHeight() which is itself nullopt (default constructed) if the tx in question
+    /// is not known. Otherwise the *blockHeight() will be a height where 0=mempool and >0=confirmed_height.
     ///
     /// Note that this implicitly will take some of the Storage locks: blocksLock, blkInfoLock, and mempoolLock.
     SubStatus getFullStatus(const HashX &txHash) const override;

--- a/src/bitcoin/heapoptional.h
+++ b/src/bitcoin/heapoptional.h
@@ -45,7 +45,7 @@ namespace bitcoin {
 
         constexpr HeapOptional() noexcept = default;
         explicit HeapOptional(const T & t) { *this = t; }
-        explicit HeapOptional(T && t) noexcept { *this = t; }
+        explicit HeapOptional(T && t) noexcept { *this = std::move(t); }
 
         /// Construct the HeapOptional in-place using argument forwarding
         template <typename ...Args>


### PR DESCRIPTION
Now that `std::variant` is available to us, we remove some of the "poor man's" `std::variant` implementations we had in the codebase.  This was for classes: `RPCMsgId` and `SubStatus`.  This refactor improves code readability and maintainability since hand-rolling a variant-workalike was painful and error-prone.

Also added unit tests for `RPCMsgId` and `SubStatus`.
