### PR TITLE
Update build instructions for building on Apple Silicon (M1 etc) with Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Undefined symbols for architecture arm64:
       Storage::UTXOBatch::UTXOBatch(Storage::UTXOCache*) in Storage.o
       Storage::UTXOBatch::UTXOBatch(Storage::UTXOCache*) in Storage.o
       Storage::addBlock(std::__1::shared_ptr<PreProcessedBlock>, bool, unsigned int, bool) in Storage.o
-      ```
+  ```
 
   The error indicates that for some reason `rocksdb` was compiled as
   an Intel exectuable (which will not work, we're on Apple Silicon

--- a/README.md
+++ b/README.md
@@ -164,8 +164,10 @@ issues. But I managed to work around them. Here is what I did:
 
 3. Build and compile Fulcrum by executing:
 
-  `qmake LIBS=-lrocksdb INCLUDEPATH=/opt/homebrew/include LIBPATH=/opt/homebrew/lib`
-  `make clean && make -j8`
+  ```
+  qmake LIBS=-lrocksdb INCLUDEPATH=/opt/homebrew/include LIBPATH=/opt/homebrew/lib
+  make clean && make -j8
+  ```
 
   This will build Fulcrum and link it with `rocksdb` from Homebrew as
   it was installed in step 1. If you do not do this you will get errors like:


### PR DESCRIPTION
The original build instructions failed to work. I added instructions on how to build Fulcrum on "modern" Macs using Homebrew.