### PR TITLE
Allow using system libraries.

### DIFF
--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -186,6 +186,14 @@ contains(LIBS, -lsimdjson) {
 }
 # /ZMQ
 
+# cppzmq
+!contains(CONFIG, config_without_bundled_cppzmq) {
+    INCLUDEPATH += src/zmq
+} else {
+    message("cppzmq: Using CLI override")
+}
+# /cppzmq
+
 # - Try and detect rocksdb and if not, fall back to the staticlib.
 # - User can suppress this behavior by specifying a "LIBS+=-lrocksdb..." on the
 #   CLI when they invoked qmake. In that case, they must set-up the LIBS+= and

--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -149,6 +149,13 @@ contains(CONFIG, config_endian_big) {
 }
 # /GIT_COMMIT=
 
+# simdjson
+contains(LIBS, -lsimdjson) {
+    message("simdjson: Using CLI override")
+    DEFINES += SYSTEM_SIMDJSON
+}
+# /simdjson
+
 # ZMQ
 !contains(LIBS, -lzmq) {
     # Test for ZMQ, and if found, add pkg-config which we will rely upon to find libs

--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -480,7 +480,7 @@ HEADERS += \
 # Enable secp256k1 compilation on x86_64 only -- we don't actually use this lib
 # yet in Fulcrum, so on platforms that aren't x86_64 it's ok to exclude it; it
 # was included in case we wish to someday verify signatures in Fulcrum, etc.
-contains(QT_ARCH, x86_64):!win32-msvc {
+contains(QT_ARCH, x86_64):!contains(CONFIG, config_without_bundled_secp256k1):!win32-msvc {
     message("Including embedded secp256k1")
 
     SOURCES += bitcoin/secp256k1/secp256k1.c

--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -149,6 +149,16 @@ contains(CONFIG, config_endian_big) {
 }
 # /GIT_COMMIT=
 
+# robin-hood-hashing
+!contains(CONFIG, config_without_bundled_robin_hood) {
+    # Robin Hood unordered_flat_map implememntation (single header and MUCH more efficient than unordered_map!)
+    HEADERS += robin_hood/robin_hood.h
+    INCLUDEPATH += src/robin_hood/
+} else {
+    message("robin-hood-hashing: Using CLI override")
+}
+# /robin-hood-hashing
+
 # simdjson
 contains(LIBS, -lsimdjson) {
     message("simdjson: Using CLI override")
@@ -401,9 +411,6 @@ HEADERS += \
     Version.h \
     WebSocket.h \
     ZmqSubNotifier.h
-
-# Robin Hood unordered_flat_map implememntation (single header and MUCH more efficient than unordered_map!)
-HEADERS += robin_hood/robin_hood.h
 
 RESOURCES += \
     resources.qrc

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -33,7 +33,7 @@
 #include "bitcoin/crypto/common.h"  // ReadLE32
 #include "bitcoin/rpc/protocol.h" // for RPC_INVALID_ADDRESS_OR_KEY
 #include "bitcoin/transaction.h"
-#include "robin_hood/robin_hood.h"
+#include <robin_hood.h>
 
 #include <algorithm>
 #include <cassert>

--- a/src/Json/Json_Parser.cpp
+++ b/src/Json/Json_Parser.cpp
@@ -56,7 +56,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // embed simdjson here, if we are on a known 64-bit platform and the header & sources are available
 #if defined(__x86_64__) || defined(_M_AMD64) || defined(__aarch64__) || defined(_M_ARM64)
-#if __has_include("simdjson/simdjson.h") && __has_include("simdjson/simdjson.cpp")
+#if defined(SYSTEM_SIMDJSON)
+#include <simdjson.h>
+#define HAVE_SIMDJSON 1
+#elif __has_include("simdjson/simdjson.h") && __has_include("simdjson/simdjson.cpp")
 #include "simdjson/simdjson.h"
 #include "simdjson/simdjson.cpp"
 #define HAVE_SIMDJSON 1

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -31,7 +31,7 @@
 
 #include "bitcoin/hash.h"
 
-#include "robin_hood/robin_hood.h"
+#include <robin_hood.h>
 
 #if __has_include(<rocksdb/advanced_cache.h>)
 // Newer rocksdb 8.1 defines the `Cache` class in this header. :/
@@ -4537,7 +4537,7 @@ namespace {
 } // end anon namespace
 
 #ifdef ENABLE_TESTS
-#include "robin_hood/robin_hood.h"
+#include <robin_hood.h>
 namespace {
 
     template<size_t NB>

--- a/src/ZmqSubNotifier.cpp
+++ b/src/ZmqSubNotifier.cpp
@@ -23,7 +23,7 @@
 #if defined(ENABLE_ZMQ)
 // real implementation
 #define ZMQ_CPP11
-#include "zmq/zmq.hpp"
+#include <zmq.hpp>
 
 #include <QRandomGenerator>
 


### PR DESCRIPTION
Fixes #152.

For example, when the dependencies are available on the system one could do:

```bash
qmake CONFIG+=config_without_bundled_cppzmq \
      CONFIG+=config_without_bundled_robin_hood \
      CONFIG+=config_without_bundled_secp256k1 \
      LIBS+=-lrocksdb \
      LIBS+=-lsimdjson
```

And it would choose the system libraries, some distributions (like Guix, Debian, etc.) may remove the bundled code, so, means to use system libraries are needed.