### PR TITLE
[README edit] Update BTC index size

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ GPLv3. See the included `LICENSE.txt` file or [visit gnu.org and read the licens
     - The node must have txindex enabled e.g. `txindex=1`.
     - The node must not be a pruning node.
     - *Optional*: For best results, enable zmq for the "hasblock" topic using e.g. `zmqpubhashblock=tcp://0.0.0.0:8433` in your `bitcoin.conf` file (zmq is only available on: Core, BCHN, BU 1.9.1+, or Litecoin Core).
-  - *Recommended hardware*: Minimum 1GB RAM, 64-bit CPU, ~40GB disk space for mainnet BCH (slightly more for BTC). For best results, use an SSD rather than an HDD.
+  - *Recommended hardware*: Minimum 1GB RAM, 64-bit CPU, ~40GB disk space for mainnet BCH, 133GB for BTC (as of Aug 2023). For best results, use an SSD rather than an HDD.
 - *For compiling*: 
   - `Qt Core` & `Qt Networking` libraries `5.12.5` or above (I use `5.15.2` myself).  Qt `5.12.4` (or earlier) is not supported.
   - *Optional but recommended*: `libzmq 4.x` development headers and library (also known as `libzmq3-dev` on Debian/Ubuntu and `zeromq-devel` on Fedora). Fulcrum will run just fine without linking against `libzmq`, but it will run better if you do link against `libzmq` and also turn on `zmqpubhashblock` notifications in `bitcoind` (zmq is only available on: Core, BCHN, or BU 1.9.1+).


### PR DESCRIPTION
Way outdated index size in the README led me to create a data disk partition that was too small for Fulcrum that crashed my initial indexing and corrupted the DB.

Current `du`:
```
41M	/fulcrum_data/blkinfo
69G	/fulcrum_data/scripthash_history
263M	/fulcrum_data/undo
5.7M	/fulcrum_data/meta
17G	/fulcrum_data/txhash2txnum
6.4G	/fulcrum_data/scripthash_unspent
15G	/fulcrum_data/utxoset
133G	/fulcrum_data/
```