### PR TITLE
RPC: Added `blockchain.*.get_first_use`

### DIFF
--- a/src/RPC.h
+++ b/src/RPC.h
@@ -60,6 +60,8 @@ namespace RPC {
         Code_ReservedError = -32000,
         /// Anything above this number is ok for us to use for application-specific errors.
         Code_Custom = -31999,
+        /// Requested item not found
+        Code_ItemNotFound = -32004,
         /// Application-level bad request, eg request a header out of range, etc
         Code_App_BadRequest = 1,
         /// Daemon problem

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -381,6 +381,7 @@ private:
     void rpc_server_version(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     // address (resurrected in protocol 1.4.3)
     void rpc_blockchain_address_get_balance(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
+    void rpc_blockchain_address_get_first_use(Client *, RPC::BatchId, const RPC::Message &); // protocol v1.5.2
     void rpc_blockchain_address_get_history(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     void rpc_blockchain_address_get_mempool(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     void rpc_blockchain_address_get_scripthash(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
@@ -398,6 +399,7 @@ private:
     void rpc_blockchain_relayfee(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     // scripthash
     void rpc_blockchain_scripthash_get_balance(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
+    void rpc_blockchain_scripthash_get_first_use(Client *, RPC::BatchId, const RPC::Message &); // protocol v1.5.2
     void rpc_blockchain_scripthash_get_history(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     void rpc_blockchain_scripthash_get_mempool(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     void rpc_blockchain_scripthash_listunspent(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
@@ -425,6 +427,7 @@ private:
     // Impl. for blockchain.scripthash.* & blockchain.address.* methods (both sets call into these).
     // Note: Validation should have already been done by caller.
     void impl_get_balance(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash, Storage::TokenFilterOption tokenFilter);
+    void impl_get_first_use(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash, const QString &address = {});
     void impl_get_history(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash, const GetHistory_FromToBH &);
     void impl_get_mempool(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash);
     void impl_listunspent(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash, Storage::TokenFilterOption tokenFilter);

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -254,6 +254,19 @@ public:
     /// thread safe -- returns confirmd, unconfirmed balance for a scripthash
     std::pair<bitcoin::Amount, bitcoin::Amount> getBalance(const HashX &, TokenFilterOption) const;
 
+    //-- scriptHash first use
+    struct FirstUse {
+        TxHash txHash;
+        int height; ///< block height. 0 = unconfirmed, -1 = unconfirmed with unconfirmed parent. Note this is ambiguous with block 0 :(
+        BlockHash blockHash; ///< the hash of the block at `height`. Will be 32-bytes of 0 for mempool txn.
+        FirstUse(const TxHash &th, int h, const BlockHash &bh) : txHash(th), height(h), blockHash(bh) {}
+    };
+
+    /// Thread-safe. Will return the first time a scripthash was used (as an output) either from the blockchain or
+    /// in mempool if never seen in a confirmed block, or a std::nullopt if the scriptHash in question was never used
+    /// as an output to a txn.
+    std::optional<FirstUse> getFirstUse(const HashX & scriptHash) const;
+
     /// thread safe, called from controller when we are up-to-date
     void updateMerkleCache(unsigned height);
 


### PR DESCRIPTION
This is currently implemented identically to the original Electrs implementation of the method.

Note that we do not support the new Rostrum optional 2nd arg "token_filter" for this method since we don't store historical token data in the db.

Also note that unlike Electrs, but like Rostrum, we do not add anything to the features map to indicate support for this method. Instead, protocol 1.5.2 or greater will support this method.

Also in this commit: bumped protocol version to 1.5.2.