### PR TITLE
Correct typos in example configurations

### DIFF
--- a/doc/fulcrum-example-config.conf
+++ b/doc/fulcrum-example-config.conf
@@ -299,7 +299,7 @@ rpcpassword = hunter1
 
 
 # Server banner text file - 'banner'
-# - DEFAULT: Send a static string "Connected to a Fulcruim xx.x server"
+# - DEFAULT: Send a static string "Connected to a Fulcrum xx.x server"
 #
 # The "banner" text file to send to clients when they request the server banner.
 # Specify a file path to a server-readable UTF-8 encoded text file (maximum file
@@ -531,7 +531,7 @@ rpcpassword = hunter1
 # default in your torrc, then specify the settings used here so that Fulcrum
 # may use the Tor proxy to discover .onion peers.
 #
-#tor_proxy = 9050   # e.g. localhost 9050. IP addr or hostname ok too: 10.0.0.1:9150, fooproxy.com:9050, etc.
+#tor_proxy = 9050   # e.g. localhost:9050. IP addr or hostname ok too: 10.0.0.1:9150, fooproxy.com:9050, etc.
 #tor_user =  # leave this out unless you specified a username in your torrc
 #tor_pass =  # leave this out unless you specified a password in your torrc
 

--- a/doc/fulcrum-quick-config.conf
+++ b/doc/fulcrum-quick-config.conf
@@ -101,7 +101,7 @@ admin = 8000  # <-- 1.2.3.4:8000 notation also accepted here
 donation = bitcoincash:qplw0d304x9fshz420lkvys2jxup38m9symky6k028
 
 # Server banner text file - 'banner'
-# - DEFAULT: Send a static string "Connected to a Fulcruim xx.x server"
+# - DEFAULT: Send a static string "Connected to a Fulcrum xx.x server"
 #banner = /path/to/banner.txt
 
 # HTTP stats bind - 'stats' - DEFAULT: None
@@ -135,6 +135,6 @@ stats = 8080  # <-- 1.2.3.4:8080 notation also accepted here
 #tor_wss_port = 50004
 
 # The proxy server to use to discover/connect-to Tor peers.
-#tor_proxy = 9050   # e.g. localhost 9050. IP addr or hostname ok too: 10.0.0.1:9150, fooproxy.com:9050, etc.
+#tor_proxy = 9050   # e.g. localhost:9050. IP addr or hostname ok too: 10.0.0.1:9150, fooproxy.com:9050, etc.
 #tor_user =  # leave this out unless you specified this in your torrc
 #tor_pass =  # leave this out unless you specified this in your torrc


### PR DESCRIPTION
Correction of minor spelling and example errors.
Servers.cpp uses `%1` to pull server info, so I am assuming the banner typo only exists in the config description.
Options.cpp uses `QString("%1:%2")` to parse the argument with the conflicting examples, so I assume the colon is required when providing server and port.  If the intent of the example was to indicate that one can list only a server without a port (where the default is only a port already), then it was ambiguous and further editing may be desirable (perhaps to simply remove the port from the first example since it is shown as the default already).