### PR TITLE
Add PeerMgr support for BTC testnet4

### DIFF
--- a/contrib/rpm/fulcrum.spec
+++ b/contrib/rpm/fulcrum.spec
@@ -1,5 +1,5 @@
 Name:    {{{ git_repo_name name="fulcrum" }}}
-Version: 1.11.0
+Version: 1.11.1
 Release: {{{ git_repo_version }}}%{?dist}
 Summary: A fast & nimble SPV server for Bitcoin Cash & Bitcoin BTC
 

--- a/doc/unix-man-page.md
+++ b/doc/unix-man-page.md
@@ -1,6 +1,6 @@
-% FULCRUM(1) Version 1.11.0 | Fulcrum Manual
+% FULCRUM(1) Version 1.11.1 | Fulcrum Manual
 % Fulcrum is written by Calin Culianu (cculianu)
-% May 23, 2024
+% August 08, 2024
 
 # NAME
 

--- a/resources.qrc
+++ b/resources.qrc
@@ -7,6 +7,7 @@
         <file>resources/bch/servers_chipnet.json</file>
         <file>resources/btc/servers.json</file>
         <file>resources/btc/servers_testnet.json</file>
+        <file>resources/btc/servers_testnet4.json</file>
         <file>resources/ltc/servers.json</file>
         <file>resources/ltc/servers_testnet.json</file>
     </qresource>

--- a/resources/btc/servers_testnet4.json
+++ b/resources/btc/servers_testnet4.json
@@ -1,0 +1,8 @@
+{
+    "blackie.c3-soft.com": {
+        "pruning": "-",
+        "s": "57010",
+        "t": "57009",
+        "version": "1.4"
+    }
+}

--- a/src/BTC.cpp
+++ b/src/BTC.cpp
@@ -171,7 +171,7 @@ namespace BTC
             {"test4",    TestNet4},    // BCHN, BU
             {"scale",    ScaleNet},    // BCHN, BU
             {"testnet3", TestNet},     // bchd
-            {"testnet4", TestNet4},    // possible future bchd
+            {"testnet4", TestNet4},    // Core, possible future bchd
             {"regtest",  RegTestNet},  // BCHN, BU, ABC, bchd, Core, LitecoinCore
             {"signet",   TestNet},     // Core only
             {"chip",     ChipNet},     // BCH only; BCHN

--- a/src/Common.h
+++ b/src/Common.h
@@ -39,7 +39,7 @@ struct InternalError : Exception { using Exception::Exception; ~InternalError() 
 struct BadArgs : Exception { using Exception::Exception; ~BadArgs() override; };
 
 #define APPNAME "Fulcrum"
-#define VERSION "1.11.0"
+#define VERSION "1.11.1"
 #ifdef QT_DEBUG
 inline constexpr bool isReleaseBuild() { return false; }
 #else

--- a/src/PeerMgr.cpp
+++ b/src/PeerMgr.cpp
@@ -96,7 +96,7 @@ void PeerMgr::startup()
     else if (net == BTC::Net::TestNet)
         parseServersDotJson(pathPrefix + "servers_testnet.json");
     else if (net == BTC::Net::TestNet4)
-        parseServersDotJson(pathPrefix + "servers_testnet4.json"); // BCH only -- will implicitly throw if somehow the coin is BTC (should never happen)
+        parseServersDotJson(pathPrefix + "servers_testnet4.json"); // BCH & BTC only -- will implicitly throw if somehow the coin is LTC (should never happen)
     else if (net == BTC::Net::ScaleNet)
         parseServersDotJson(pathPrefix + "servers_scalenet.json"); // BCH only -- will implicitly throw if somehow the coin is BTC (should never happen)
     else if (net == BTC::Net::ChipNet)


### PR DESCRIPTION
Closes #249 

This series of commits:

- Documents the fact that Fulcrum supports BTC testnet4 in the code
- Adds peering support for BTC testnet4 by adding required file for peering: `resources/btc/servers_testnet4.json`, which contains as the only server (for now): `blackie.c3-soft.com`
- We also bump Fulcrum to 1.11.1 to signify the first version that supports peering for BTC testnet4.
