### PR TITLE
ZMQ: Add optional support for "pubhashtx" ZMQ message from bitcoind

### DIFF
--- a/doc/fulcrum-example-config.conf
+++ b/doc/fulcrum-example-config.conf
@@ -1019,6 +1019,28 @@ rpcpassword = hunter1
 #pidfile = /path/to/fulcrum.pid
 
 
+# ZMQ allow "hashtx" messages = 'zmq_allow_hashtx' - DEFAULT: false
+#
+# Fulcrum must be compiled with ZMQ support for this option to have any effect.
+#
+# If enabled, Fulcrum will subscribe to bitcoind `pubhashtx` ZMQ notifications
+# (if enabled on the bitcoind side), in addition to the usual `pubhashblock`
+# notifications Fulcrum normally subscribes to. The effect of this is that
+# Fulcrum will be notified for every txn entering the mempool (and confirmed
+# in a block!) and as such it will immediately initiate a blockchain and/or
+# mempool synch after these messages arrive. Thus, as new txns arrive in the
+# mempool, Fulcrum will "see" them a bit sooner if this option is enabled.
+#
+# Note that bitcoind `pubhashtx` messages are extremely spammy and waste
+# cycles and bandwidth, which is why this option must be explicitly enabled
+# in Fulcrum even if the remote bitcoind has `pubhashtx` ZMQ notifications
+# enabled. It is the opinion of the author of Fulcrum that `pubhashtx` ZMQ
+# notifications are too spammy and will result in overall negative performance
+# for Fulcrum if enabled. However, some users may wish to opt-in to this
+# facility for lower-latency notifications as txns arrive to the node.
+#
+#zmq_allow_hashtx = false
+
 
 #-------------------------------------------------------------------------------
 # Reusable Payment Address (RPA) Options

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -1498,6 +1498,16 @@ void App::parseArgs()
         // log this later in case we are in syslog mode
         Util::AsyncOnObject(this, [ht, confKey]{ Debug() << "config: " << confKey << " = " << ht; });
     }
+
+    // conf: zmq_allow_hashtx
+    if (conf.hasValue("zmq_allow_hashtx")) {
+        bool ok{};
+        const bool val = conf.boolValue("zmq_allow_hashtx", Options::defaultZmqAllowHashTx, &ok);
+        if (!ok)
+            throw BadArgs("zmq_allow_hashtx: bad value. Specify a boolean value such as 0, 1, true, false, yes, no");
+        options->zmqAllowHashTx = val;
+        Util::AsyncOnObject(this, [val]{ DebugM("config: zmq_allow_hashtx = ", val); });
+    }
 }
 
 namespace {

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -1304,7 +1304,7 @@ void Controller::process(bool beSilentIfUpToDate)
             } else
                 DebugM("zmq hashblock received while we were synching, however it matches our latest tip, ignoring ...");
         } else if (!sm->mostRecentZmqHashTxNotif.isEmpty()) {
-            if (!storage->isRecentlySeenTx(sm->mostRecentZmqHashTxNotif)) {
+            if (!storage->isMaybeRecentlySeenTx(sm->mostRecentZmqHashTxNotif)) {
                 // While we were synching -- a zmq notification happened -- and it told us about a txhash that we
                 // maybe have not yet seen. Just to be sure, schedule us to run again immediately.
                 polltimeout = 0;
@@ -1585,7 +1585,7 @@ bool Controller::process_VerifyAndAddBlock(PreProcessedBlockPtr ppb)
         const auto nLeft = qMax(sm->endHeight - (sm->dlResultsHtNext-1), 0U);
         const bool saveUndoInfo = !sm->suppressSaveUndo && int(ppb->height) > (sm->ht - int(storage->configuredUndoDepth()));
 
-        storage->addBlock(ppb, saveUndoInfo, nLeft, masterNotifySubsFlag);
+        storage->addBlock(ppb, saveUndoInfo, nLeft, masterNotifySubsFlag, options->zmqAllowHashTx);
 
     } catch (const HeaderVerificationFailure & e) {
         DebugM("addBlock exception: ", e.what());

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -132,8 +132,10 @@ void Controller::startup()
 
         conns += connect(bitcoindmgr.get(), &BitcoinDMgr::zmqNotificationsChanged, this, [this](BitcoinDZmqNotifications bdzmqs) {
             // NB: this only fires if ZmqSubNotifier::isAvailable() == true
+            using enum ZmqTopic::Tag;
             for (const auto topic : zmqs.allTopics) {
-                if (const auto & topicAddr = bdzmqs.value(topic.str()); !topicAddr.isEmpty()) {
+                if (const auto & topicAddr = bdzmqs.value(topic.str());
+                        !topicAddr.isEmpty() && /* if hashtx allowed: */ (topic.tag != HashTx || options->zmqAllowHashTx)) {
                     auto & state = zmqs[topic];
                     state.lastKnownAddr = topicAddr;
                     DebugM("\"", topic.str(), "\" topic address: ", state.lastKnownAddr);

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -114,7 +114,10 @@ void Controller::startup()
         conns += connect(bitcoindmgr.get(), &BitcoinDMgr::coinDetected, this, &Controller::on_coinDetected,
                          /* NOTE --> */ Qt::DirectConnection);
         conns += connect(bitcoindmgr.get(), &BitcoinDMgr::allConnectionsLost, this, waitForBitcoinD);
-        conns += connect(bitcoindmgr.get(), &BitcoinDMgr::allConnectionsLost, this, &Controller::zmqHashBlockStop); // stop zmq unconditionally
+        conns += connect(bitcoindmgr.get(), &BitcoinDMgr::allConnectionsLost, this, [this]{
+            // stop all zmq unconditionally
+            for (const auto topic : zmqs.allTopics) zmqTopicStop(topic);
+        });
         conns += connect(bitcoindmgr.get(), &BitcoinDMgr::gotFirstGoodConnection, this, [this](quint64 id) {
             // connection to kick off our 'process' method once the first auth is received
             if (lostConn) {
@@ -123,29 +126,38 @@ void Controller::startup()
                 DebugM("Auth recvd from bicoind with id: ", id, ", proceeding with processing ...");
                 callOnTimerSoonNoRepeat(smallDelay, callProcessTimer, [this]{process();}, true);
 
-                // also (re)start the zmq notifier if we had one before and bitcoind came back (but only if we are
+                // also (re)start the zmq notifier(s) if we had any before and bitcoind came back (but only if we are
                 // "ready" and able to serve connections)
-                if (!lastKnownZmqHashBlockAddr.isEmpty() && srvmgr)
-                    zmqHashBlockStart();
+                if (srvmgr) {
+                    for (const auto & [topic, state] : zmqs.map) {
+                        if (!state.lastKnownAddr.isEmpty())
+                            zmqTopicStart(topic);
+                    }
+                }
             }
         });
 
-        conns += connect(bitcoindmgr.get(), &BitcoinDMgr::zmqNotificationsChanged, this, [this](BitcoinDZmqNotifications zmqs) {
+        conns += connect(bitcoindmgr.get(), &BitcoinDMgr::zmqNotificationsChanged, this, [this](BitcoinDZmqNotifications bdzmqs) {
             // NB: this only fires if ZmqSubNotifier::isAvailable() == true
-            if (!(lastKnownZmqHashBlockAddr = zmqs.value("hashblock")).isEmpty()) {
-                DebugM("\"hashblock\" topic address: ", lastKnownZmqHashBlockAddr);
-                // We only start the ZMQ notifier once we are "ready" and the servers are started
-                // (see also one of the upToDate triggered slots below)
-                if (srvmgr) {
-                    // maybe restart if it was running (to apply new address)
-                    if (zmqHashBlockNotifier && zmqHashBlockNotifier->isRunning()) {
-                        DebugM("applying new hashblock address to already-running zmq notifier");
+            for (const auto topic : zmqs.allTopics) {
+                if (const auto & topicAddr = bdzmqs.value(topic.str()); !topicAddr.isEmpty()) {
+                    auto & state = zmqs[topic];
+                    state.lastKnownAddr = topicAddr;
+                    DebugM("\"", topic.str(), "\" topic address: ", state.lastKnownAddr);
+                    // We only start the ZMQ notifier once we are "ready" and the servers are started
+                    // (see also one of the upToDate triggered slots below)
+                    if (srvmgr) {
+                        // maybe restart if it was running (to apply new address)
+                        if (state.notifier && state.notifier->isRunning()) {
+                            DebugM("applying new ", topic.str(), " address to already-running zmq notifier");
+                        }
+                        zmqTopicStart(topic); // may re-start existing notifier, or create a new one if none exists
                     }
-                    zmqHashBlockStart(); // may re-start existing notifier, or create a new one if none exists
+                } else {
+                    // bitcoind lacks this topicName endpoint (e.g. lacks "hashblock" or "hashtx") -- stop existing
+                    // notifier, if it exists
+                    zmqTopicStop(topic);
                 }
-            } else {
-                // bitcoind lacks the "hashblock" endpoint -- stop existing hashblock notifier, if it exists
-                zmqHashBlockStop();
             }
         });
 
@@ -197,8 +209,9 @@ void Controller::startup()
 
             // If BitcoinDMgr told us about a ZMQ hashblock notification address, start the ZMQ notifier
             // (this does not happen if no ZMQ enabled at compile-time)
-            if (!lastKnownZmqHashBlockAddr.isEmpty())
-                zmqHashBlockStart();
+            for (const auto & [topic, state] : zmqs.map)
+                if (!state.lastKnownAddr.isEmpty())
+                    zmqTopicStart(topic);
         }
     }, Qt::QueuedConnection);
 
@@ -353,7 +366,13 @@ void Controller::cleanup()
     stopFlag = true;
     stop();
     tasks.clear(); // deletes all tasks asap
-    if (zmqHashBlockNotifier) { Log("Stopping ZMQ notifier ..."); zmqHashBlockNotifier.reset(); }
+    for (auto & [t, state] : zmqs.map) { // Stop ZMQ notifiers
+        if (state.notifier) {
+            Log() << "Stopping " << state.notifier->objectName() << " ...";
+            state.notifier.reset();
+        }
+
+    }
     if (srvmgr) { Log("Stopping SrvMgr ... "); srvmgr->cleanup(); srvmgr.reset(); }
     if (bitcoindmgr) { Log("Stopping BitcoinDMgr ... "); bitcoindmgr->cleanup(); bitcoindmgr.reset(); }
     if (storage) { Log("Closing storage ..."); storage->cleanup(); storage.reset(); }
@@ -848,7 +867,10 @@ struct Controller::StateMachine
     void * mostRecentGetChainInfoTask = nullptr;
 
     /// will be valid and not empty only if a zmq hashblock notification happened while we were running the block & mempool synch task
-    QByteArray mostRecentZmqNotif;
+    QByteArray mostRecentZmqHashBlockNotif;
+
+    /// will be valid and not empty only if a zmq hashtx notification happened while we were running the block & mempool synch task
+    QByteArray mostRecentZmqHashTxNotif;
 
     /// This is valid only if we are in an initial sync
     std::optional<Storage::InitialSyncRAII> initialSyncRaii;
@@ -1283,8 +1305,8 @@ void Controller::process(bool beSilentIfUpToDate)
         enablePollTimer = true;
         emit synchFailure();
     } else if (sm->state == State::End) {
-        if (!sm->mostRecentZmqNotif.isEmpty()) {
-            if (sm->mostRecentZmqNotif != storage->latestTip().second) {
+        if (!sm->mostRecentZmqHashBlockNotif.isEmpty()) {
+            if (sm->mostRecentZmqHashBlockNotif != storage->latestTip().second) {
                 // While we were synching -- a zmq notification happened -- and it told us about a block header that is
                 // not our latest tip. Just to be sure, schedule us to run again immediately.
                 polltimeout = 0;
@@ -1292,6 +1314,15 @@ void Controller::process(bool beSilentIfUpToDate)
                        " another bitcoind update immediately ...");
             } else
                 DebugM("zmq hashblock received while we were synching, however it matches our latest tip, ignoring ...");
+        } else if (!sm->mostRecentZmqHashTxNotif.isEmpty()) {
+            if (!storage->isTxInMempool(sm->mostRecentZmqHashTxNotif)) {
+                // While we were synching -- a zmq notification happened -- and it told us about a txhash that we
+                // lack in mempool. Just to be sure, schedule us to run again in 500 msec.
+                polltimeout = int(Options::minPollTimeSecs * 1e3);
+                DebugM("zmq hashtx received with a (possibly) new txn while we were synching, re-scheduling"
+                       " another bitcoind update immediately ...");
+            } else
+                DebugM("zmq hashtx received while we were synching, however we have the txn already in mempool, ignoring ...");
         }
         {
             std::lock_guard g(smLock);
@@ -1383,12 +1414,22 @@ void Controller::process(bool beSilentIfUpToDate)
         callOnTimerSoonNoRepeat(polltimeout, pollTimerName, [this]{ on_Poll(); });
 }
 
-void Controller::on_Poll(std::optional<QByteArray> zmqBlockHash)
+void Controller::on_Poll(std::optional<std::pair<ZmqTopic, QByteArray>> zmqNotifHash)
 {
     if (!sm)
         process(true); // process immediately
-    else if (zmqBlockHash)
-        sm->mostRecentZmqNotif = std::move(*zmqBlockHash); // deferred processing for when current task completes
+    else if (zmqNotifHash) {
+        // deferred processing for when current task completes
+        using T = ZmqTopic::Tag;
+        switch (zmqNotifHash->first.tag) {
+        case T::HashBlock:
+            sm->mostRecentZmqHashBlockNotif = std::move(zmqNotifHash->second);
+            break;
+        case T::HashTx:
+            sm->mostRecentZmqHashTxNotif = std::move(zmqNotifHash->second);
+            break;
+        }
+    }
 }
 
 // this is called by the 2 below on_putBlock and on_putRpaIndex functions to avoid boilerplate
@@ -1725,11 +1766,13 @@ auto Controller::stats() const -> Stats
     }
     { // ZMQ
         QVariantMap m2;
-        if (zmqHashBlockNotifier && zmqHashBlockNotifier->isRunning()) {
-            QVariantMap m3;
-            m3["address"] = lastKnownZmqHashBlockAddr;
-            m3["notifications"] = zmqHashBlockNotifCt;
-            m2["hashblock"] = m3;
+        for (const auto & [topic, state] : zmqs.map) {
+            if (state.notifier && state.notifier->isRunning()) {
+                QVariantMap m3;
+                m3["address"] = state.lastKnownAddr;
+                m3["notifications"] = static_cast<qulonglong>(state.notifCt);
+                m2[topic.str()] = m3;
+            }
         }
         m["ZMQ Notifiers (active)"] = m2;
     }
@@ -1857,23 +1900,27 @@ std::tuple<size_t, size_t, size_t> Controller::nTxInOutSoFar() const
     return {nTx, nIn, nOut};
 }
 
-void Controller::zmqHashBlockStart()
+void Controller::zmqTopicStart(ZmqTopic t)
 {
     if (!ZmqSubNotifier::isAvailable()) {
         DebugM(__func__, ": zmq unavailable, ignoring start request");
-        zmqHashBlockNotifier.reset(); // ensure it's dead -- should never be alive in this case (indicates a bug).
+        if (auto *state = zmqs.find(t)) {
+            state->notifier.reset(); // ensure it's dead -- should never be alive in this case (indicates a bug).
+            zmqs.map.erase(t);
+        }
         return;
     }
-    if (!zmqHashBlockNotifier) {
+    auto &state = zmqs[t];
+    if (!state.notifier) {
         // first time through, create a new notifier
-        zmqHashBlockNotifier = std::make_unique<ZmqSubNotifier>(this);
-        zmqHashBlockNotifier->setObjectName("ZMQ Notifier (hashblock)");
+        state.notifier = std::make_unique<ZmqSubNotifier>(this);
+        state.notifier->setObjectName(QString("ZMQ Notifier (%1)").arg(t.str()));
         // connect signals
-        conns += connect(zmqHashBlockNotifier.get(), &ZmqSubNotifier::errored, this, [](const QString &errMsg){
-            Warning() << "zmqHashBlockNotifier: " << errMsg;
+        conns += connect(state.notifier.get(), &ZmqSubNotifier::errored, this, [t](const QString &errMsg){
+            Warning() << "zmqNotifier \"" << t.str() << "\": " << errMsg;
         });
-        conns += connect(zmqHashBlockNotifier.get(), &ZmqSubNotifier::gotMessage, this, [this](const QString &topic, const QByteArrayList &parts) {
-            std::optional<QByteArray> optHash;
+        conns += connect(state.notifier.get(), &ZmqSubNotifier::gotMessage, this, [this, t](const QString &topic, const QByteArrayList &parts) {
+            std::optional<std::pair<ZmqTopic, QByteArray>> optPair;
             if (Debug::isEnabled()) {
                 Debug d;
                 d << "got zmq " << topic << " notification: ";
@@ -1884,46 +1931,63 @@ void Controller::zmqHashBlockStart()
                         d << QString(part);
                     else if (i == 3) // sequence number (little endian)
                         d << bitcoin::ReadLE32(reinterpret_cast<const uint8_t *>(part.constData()));
-                    else { // block hash (binary, big endian byte order)
-                        optHash = part;
+                    else { // block or tx hash (binary, big endian byte order)
+                        optPair.emplace(t, part);
                         d << QString(Util::ToHexFast(part));
                     }
                  }
             }
-            if (!optHash && parts.size() >= 2) {
-                const auto &part = parts[1]; // blockhash is second element
+            if (!optPair && parts.size() >= 2) {
+                const auto &part = parts[1]; // blockhash or txhash is second element
                 if (part.size() == 32) // ensure proper format
-                    optHash = part; // this is already in big endian order (which is how we also store them)
+                    optPair.emplace(t, part); // this is already in big endian order (which is how we also store them)
             }
-            if (UNLIKELY(!optHash))
-                Error() << "Unexpected format: got zmq hashblock notification but it is missing the block hash!";
-            else
-                ++zmqHashBlockNotifCt;
+            if (UNLIKELY(!optPair))
+                Error() << "Unexpected format: got zmq " << topic << " notification but it is missing the hash!";
+            else {
+                if (auto *state = zmqs.find(t)) [[likely]]
+                    ++state->notifCt; // this branch should always be taken
+                else
+                    Error() << "INTERNAL ERROR: Missing ZmqPvt::TopicState object for \"" << topic << "\"!. FIXME!";
+            }
             // notify (may end up calling this->process())
-            on_Poll(std::move(optHash));
+            on_Poll(std::move(optPair));
         });
     }
-    if (zmqHashBlockNotifier->isRunning())
-        zmqHashBlockNotifier->stop();
-    if (lastKnownZmqHashBlockAddr.isEmpty()) {
-        DebugM(__func__, ": zmq hashblock address is empty, ignoring start request");
+    if (state.notifier->isRunning())
+        state.notifier->stop();
+    if (state.lastKnownAddr.isEmpty()) {
+        DebugM(__func__, ": zmq ", t.str(), " address is empty, ignoring start request");
         return;
     }
-    if (!zmqHashBlockDidLogStartup) {
-        zmqHashBlockDidLogStartup = true;
-        Log() << "Starting " << zmqHashBlockNotifier->objectName() << " ...";
+    if (!state.didLogStartup) {
+        state.didLogStartup = true;
+        Log() << "Starting " << state.notifier->objectName() << " ...";
     }
-    if (!zmqHashBlockNotifier->start(lastKnownZmqHashBlockAddr, "hashblock", 30 * 60 * 1000 /* idle timeout: 30 mins in msecs */)) {
+    if (!state.notifier->start(state.lastKnownAddr, t.str(), 30 * 60 * 1000 /* idle timeout: 30 mins in msecs */)) {
         Warning() << __func__ << ": start failed";
     }
 }
 
-void Controller::zmqHashBlockStop()
+void Controller::zmqTopicStop(ZmqTopic t)
 {
-    if (!zmqHashBlockNotifier || !zmqHashBlockNotifier->isRunning())
-        return;
-    zmqHashBlockNotifier->stop();
+    if (auto *state = zmqs.find(t); state && state->notifier && state->notifier->isRunning()) {
+        state->notifier->stop();
+    }
 }
+
+const char *Controller::ZmqPvt::Topic::str() const noexcept
+{
+    switch (tag) {
+    case Tag::HashBlock: return "hashblock";
+    case Tag::HashTx: return "hashtx";
+    }
+    return "unknown";
+}
+
+Controller::ZmqPvt::TopicState::~TopicState() {}
+Controller::ZmqPvt::~ZmqPvt() {}
+auto Controller::ZmqPvt::operator[](Topic t) -> TopicState & { return map[t]; }
 
 // --- Debug dump support
 void Controller::dumpScriptHashes(const QString &fileName)

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -271,6 +271,8 @@ private:
 
     /// (re)starts all zmq notifiers that have a non-empty lastKnownAddr
     void zmqStartAllKnown();
+    /// Stops all notifiers that are running. If cleanup==true also deletes all notifier instances.
+    void zmqStopAll(bool cleanup = false);
 
     /// Litecoin only: Ignore these txhashes from mempool (don't download them). This gets cleared each time
     /// before the first SynchMempool after we receive a new block, then is persisted for all the SynchMempools

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -227,7 +227,7 @@ private:
             constexpr auto operator<=>(const Topic &) const noexcept = default;
         };
         using enum Topic::Tag;
-        static constexpr const Topic allTopics[] = { {HashBlock}, {HashTx} /* <-- very spammy */ };
+        static constexpr const Topic allTopics[] = { {HashBlock}, /* {HashTx} <-- very spammy, disabled for now */ };
         static constexpr size_t nTopics() noexcept { return std::size(allTopics); }
         struct TopicHasher {
             std::hash<int> hasher;

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -254,6 +254,11 @@ private:
         TopicState & operator[](Topic t); // must define in Controller.cpp translation unit due to incomplete ZmqSubNotifier type
         TopicState *find(Topic t) noexcept { if (auto it = map.find(t); it != map.end()) return &it->second; return nullptr; }
 
+        auto begin() { return map.begin(); }
+        auto begin() const { return map.begin(); }
+        auto end() { return map.end(); }
+        auto end() const { return map.end(); }
+
         ~ZmqPvt(); // must define d'tor in Controller.cpp translation unit due to incomplete ZmqSubNotifier type
     } zmqs;
 
@@ -262,6 +267,9 @@ private:
     /// (re)starts listening for notifications from the ZmqNotifier for this topic; called if we received a valid zmq
     /// address for this topic from BitcoinDMgr, after servers are started.
     void zmqTopicStart(ZmqTopic topic);
+
+    /// (re)starts all zmq notifiers that have a non-empty lastKnownAddr
+    void zmqStartAllKnown();
 
     /// Litecoin only: Ignore these txhashes from mempool (don't download them). This gets cleared each time
     /// before the first SynchMempool after we receive a new block, then is persisted for all the SynchMempools

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -227,7 +227,7 @@ private:
             constexpr auto operator<=>(const Topic &) const noexcept = default;
         };
         using enum Topic::Tag;
-        static constexpr const Topic allTopics[] = { {HashBlock}, /* {HashTx} <-- very spammy, disabled for now */ };
+        static constexpr const Topic allTopics[] = { {HashBlock}, {HashTx}  /* very spammy, disabled unless zmq_allow_hashtx = true in config */ };
         static constexpr size_t nTopics() noexcept { return std::size(allTopics); }
         struct TopicHasher {
             std::hash<int> hasher;

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -26,14 +26,17 @@
 #include "Storage.h"
 #include "SrvMgr.h"
 
+#include <array>
 #include <atomic>
 #include <concepts> // for std::derived_from
+#include <functional> // for std::hash
 #include <memory>
 #include <optional>
 #include <tuple>
 #include <shared_mutex>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility> // for std::pair
 
 class CtlTask;
 class SSLCertMonitor;
@@ -136,11 +139,6 @@ protected:
     Stats stats() const override; // from StatsMixin
     Stats debug(const StatsParams &) const override; // from StatsMixin
 
-    /// Called from the poll timer to restart the state machine and get latest blocks and mempool (process());
-    /// Also called if we received a zmq hashblock notification (in which case it will be called with the valid
-    /// header hash, already in big endian byte order).
-    void on_Poll(std::optional<QByteArray> zmqBlockHash = std::nullopt);
-
 protected slots:
     void process(bool beSilentIfUpToDate); ///< generic callback to advance state
     void process() override { process(false); } ///< from ProcessAgainMixin
@@ -219,19 +217,50 @@ private:
     /// If --dump-sh was specified on CLI, this will execute at startup() time right after storage has been loaded. May throw.
     void dumpScriptHashes(const QString &fileName);
 
-    /// Will be nullptr if zmq disabled or bitcoind lacks a "hashblock" endpoint
-    std::unique_ptr<ZmqSubNotifier> zmqHashBlockNotifier;
-    /// Populated from bitcoindmgr's zmqNotificationsChanged signal. If empty, remote has no hashblock notifications
-    /// advertised in `getzmqnotifications`
-    QString lastKnownZmqHashBlockAddr;
-    /// Permanently latched to true after the first time we start the ZMQ notifier (to suppress logging for subsequent re-starts)
-    bool zmqHashBlockDidLogStartup = false;
-    /// The number of notifications received from bitcoind via ZMQ total since app start.
-    unsigned zmqHashBlockNotifCt = 0;
+    /// Stores ZMQ notification state for "hashblock" and "hashtx" ZMQ topics from remote bitcoind.
+    struct ZmqPvt {
+        struct Topic {
+            enum class Tag : uint8_t { HashBlock, HashTx };
+            const Tag tag;
+            // returns: "hashblock" or "hashtx"
+            const char *str() const noexcept;
+            constexpr auto operator<=>(const Topic &) const noexcept = default;
+        };
+        static inline constexpr const std::array<Topic, 2u> allTopics = {Topic{.tag = Topic::Tag::HashBlock}, {Topic::Tag::HashTx}};
+        static inline constexpr size_t nTopics() noexcept { return allTopics.size(); }
+        struct TopicHasher {
+            std::hash<int> hasher;
+            inline size_t operator()(Topic t) const noexcept { return hasher(static_cast<int>(t.tag)); }
+        };
 
-    /// (re)starts listening for notifications from the zmqHashBlockNotifier; called if we received a valid zmq address
-    /// from BitcoinDMgr, after servers are started.
-    void zmqHashBlockStart();
+        struct TopicState {
+            using SubNotifierPtr = std::unique_ptr<ZmqSubNotifier>;
+            /// Will be nullptr if zmq disabled or bitcoind lacks this topic endpoint
+            SubNotifierPtr notifier;
+            /// Populated from bitcoindmgr's zmqNotificationsChanged signal. If empty, remote has no notifications
+            /// advertised in `getzmqnotifications` for this topic.
+            QString lastKnownAddr;
+            /// Permanently latched to true after the first time we start this ZMQ notifier (to suppress logging for subsequent re-starts)
+            bool didLogStartup = false;
+            /// The number of notifications received from bitcoind via ZMQ for this topic since app start.
+            size_t notifCt = 0u;
+            ~TopicState(); // must define d'tor in Controller.cpp translation unit due to incomplete ZmqSubNotifier type
+        };
+
+        using TopicNotifierMap = std::unordered_map<Topic, TopicState, TopicHasher>;
+        TopicNotifierMap map{nTopics()};
+
+        TopicState & operator[](Topic t); // must define in Controller.cpp translation unit due to incomplete ZmqSubNotifier type
+        TopicState *find(Topic t) noexcept { if (auto it = map.find(t); it != map.end()) return &it->second; return nullptr; }
+
+        ~ZmqPvt(); // must define d'tor in Controller.cpp translation unit due to incomplete ZmqSubNotifier type
+    } zmqs;
+
+    using ZmqTopic = ZmqPvt::Topic;
+
+    /// (re)starts listening for notifications from the ZmqNotifier for this topic; called if we received a valid zmq
+    /// address for this topic from BitcoinDMgr, after servers are started.
+    void zmqTopicStart(ZmqTopic topic);
 
     /// Litecoin only: Ignore these txhashes from mempool (don't download them). This gets cleared each time
     /// before the first SynchMempool after we receive a new block, then is persisted for all the SynchMempools
@@ -254,10 +283,16 @@ private:
     /// its current process() invocation.
     bool checkRpaIndexNeedsSync(int tipHeight);
 
+protected:
+    /// Called from the poll timer to restart the state machine and get latest blocks and mempool (process());
+    /// Also called if we received a zmq hashblock or hashtx notification (in which case it will be called with the valid
+    /// header or tx hash, already in big endian byte order).
+    void on_Poll(std::optional<std::pair<ZmqTopic, QByteArray>> zmqNotifHash = std::nullopt);
+
 private slots:
-    /// Stops the zmqHashBlockNotifier; called if we received an empty hashblock endpoint address from BitcoinDMgr or
+    /// Stops the ZmqNotifier for this topic; called if we received an empty address for this topic from BitcoinDMgr or
     /// when all connections to bitcoind are lost
-    void zmqHashBlockStop();
+    void zmqTopicStop(ZmqTopic topic);
 };
 
 /// Abstract base class for our private internal tasks. Concrete implementations are in Controller.cpp.

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -173,7 +173,7 @@ private:
 
     /// The default 'errored' handler used if a task was created with connectErroredSignal=true in newTask above.
     void genericTaskErrored();
-    static constexpr auto pollTimerName = "pollForNewHeaders";
+    static constexpr auto pollTimerName = "pollForBlockchainChanges";
 
     const std::shared_ptr<const Options> options;
     const SSLCertMonitor * const sslCertMonitor;
@@ -227,7 +227,7 @@ private:
             constexpr auto operator<=>(const Topic &) const noexcept = default;
         };
         using enum Topic::Tag;
-        static constexpr const Topic allTopics[] = { {HashBlock}, /* {HashTx} <-- disabled because too spammy */ };
+        static constexpr const Topic allTopics[] = { {HashBlock}, {HashTx} /* <-- very spammy */ };
         static constexpr size_t nTopics() noexcept { return std::size(allTopics); }
         struct TopicHasher {
             std::hash<int> hasher;
@@ -258,6 +258,7 @@ private:
         auto begin() const { return map.begin(); }
         auto end() { return map.end(); }
         auto end() const { return map.end(); }
+        size_t erase(Topic t);
 
         ~ZmqPvt(); // must define d'tor in Controller.cpp translation unit due to incomplete ZmqSubNotifier type
     } zmqs;

--- a/src/Options.h
+++ b/src/Options.h
@@ -313,6 +313,10 @@ public:
                              defaultStartHeightOtherNets = 0;
         int requestedStartHeight = -1;
     } rpa;
+
+    // config: zmq_allow_hashtx
+    static constexpr bool defaultZmqAllowHashTx = false;
+    bool zmqAllowHashTx = defaultZmqAllowHashTx;
 };
 
 /// A class encapsulating a simple read-only config file format.  The format is similar to the bitcoin.conf format

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -4624,6 +4624,11 @@ auto Storage::mutableMempool() -> std::pair<Mempool &, ExclusiveLockGuard>
     return {p->mempool, ExclusiveLockGuard{p->mempoolLock}};
 }
 
+bool Storage::isTxInMempool(const TxHash &txhash) const
+{
+    return mempool().first.txs.contains(txhash);
+}
+
 void Storage::refreshMempoolHistogram()
 {
     Tic t0;

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1178,7 +1178,8 @@ struct Storage::Pvt
         mutable std::atomic_int rpaNeedsFullCheckCachedVal = -1; // if > -1, the last value written to the DB. If < 0, no cached val, just read from DB when querying isRpaNeedsFullCheck()
     } rpaInfo;
 
-    /// Set of recent block txids seen, only valid if "notify" is enabled. Guarded by `blocksLock`.
+    /// Set of recent block txids seen, only valid if "notify" is enabled and if app-wide zmq "hashtx" notifs are enabled.
+    /// Guarded by `blocksLock`.
     std::unordered_set<TxHash, HashHasher> recentBlockTxHashes;
 };
 
@@ -3274,7 +3275,7 @@ std::optional<TXOInfo> Storage::utxoGet(const TXO &txo)
     return ret;
 }
 
-void Storage::addBlock(PreProcessedBlockPtr ppb, bool saveUndo, unsigned nReserve, bool notifySubs)
+void Storage::addBlock(PreProcessedBlockPtr ppb, bool saveUndo, unsigned nReserve, bool notifySubs, const bool trackRecentBlockTxHashes)
 {
     assert(bool(ppb) && bool(p));
 
@@ -3313,13 +3314,18 @@ void Storage::addBlock(PreProcessedBlockPtr ppb, bool saveUndo, unsigned nReserv
             const auto rsvsz = static_cast<Mempool::TxHashNumMap::size_type>(sz > 0 ? sz-1 : 0);
             Mempool::TxHashNumMap txidMap(/* bucket_count: */ rsvsz);
             notify->txidsAffected.reserve(rsvsz);
-            p->recentBlockTxHashes.reserve(sz);
-            if (sz > 0u) [[likely]] p->recentBlockTxHashes.insert(ppb->txInfos[0].hash); // add coinbase txhash to recent set
+            if (trackRecentBlockTxHashes) {
+                p->recentBlockTxHashes.reserve(sz);
+                if (sz > 0u) [[likely]]
+                    p->recentBlockTxHashes.insert(ppb->txInfos[0].hash); // add coinbase txhash to recent set
+            }
             for (std::size_t i = 1 /* skip coinbase */; i < sz; ++i) {
                 const auto & txHash = ppb->txInfos[i].hash;
                 txidMap.emplace(txHash, blockTxNum0 + i);
                 notify->txidsAffected.insert(txHash); // add to notify set for txSubsMgr
-                p->recentBlockTxHashes.insert(txHash); // add to "recently seen" set for the hashtx zmq notifier spam suppressor
+                if (trackRecentBlockTxHashes)
+                    // add to "recently seen" set for the hashtx zmq notifier spam suppressor
+                    p->recentBlockTxHashes.insert(txHash);
             }
             Mempool::ScriptHashesAffectedSet affected;
             // Pre-reserve some capacity for the tmp affected set to avoid much rehashing.
@@ -3727,6 +3733,7 @@ BlockHeight Storage::undoLatestBlock(bool notifySubs)
             notify->txidsAffected.merge(Util::keySet<NotifySet>(p->mempool.txs)); // for txSubsMgr
         }
         p->mempool.clear(); // make sure mempool is clean (see note above as to why)
+        p->recentBlockTxHashes.clear(); // these are no longer relevant if undoing
 
         const auto [tip, header] = p->headerVerifier.lastHeaderProcessed();
         if (tip <= 0 || header.length() != p->blockHeaderSize()) throw UndoInfoMissing("No header to undo");
@@ -4631,7 +4638,7 @@ auto Storage::mutableMempool() -> std::pair<Mempool &, ExclusiveLockGuard>
     return {p->mempool, ExclusiveLockGuard{p->mempoolLock}};
 }
 
-bool Storage::isRecentlySeenTx(const TxHash &txhash) const
+bool Storage::isMaybeRecentlySeenTx(const TxHash &txhash) const
 {
     if (mempool().first.txs.contains(txhash)) return true;
     SharedLockGuard g{p->blocksLock};

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -295,8 +295,9 @@ public:
     /// Caller must hold the returned ExclusiveLockGuard for as long as they use the reference otherwise bad things happen!
     std::pair<Mempool &, ExclusiveLockGuard> mutableMempool();
 
-    /// Returns true if txhash is in the mempool, false otherwise. Thread-safe (takes mempool shared lock internally).
-    bool isTxInMempool(const TxHash &txhash) const;
+    /// Returns true if txhash is in the mempool or in a recent block, false otherwise.
+    /// Thread-safe (takes mempool shared lock and/or blocks lock internally).
+    bool isRecentlySeenTx(const TxHash &txhash) const;
 
     /// Thread-safe. Query db (but not mempool) for a UTXO, and return its info if found.  May throw on database error.
     /// (Does not take the blocks lock)

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -295,6 +295,9 @@ public:
     /// Caller must hold the returned ExclusiveLockGuard for as long as they use the reference otherwise bad things happen!
     std::pair<Mempool &, ExclusiveLockGuard> mutableMempool();
 
+    /// Returns true if txhash is in the mempool, false otherwise. Thread-safe (takes mempool shared lock internally).
+    bool isTxInMempool(const TxHash &txhash) const;
+
     /// Thread-safe. Query db (but not mempool) for a UTXO, and return its info if found.  May throw on database error.
     /// (Does not take the blocks lock)
     std::optional<TXOInfo> utxoGetFromDB(const TXO &, bool throwIfMissing = false);

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -172,7 +172,8 @@ public:
     /// the block is accepted.  A successful return from this function without throwing indicates success.
     ///
     /// Note: you can only add blocks in serial sequence from 0 -> latest.
-    void addBlock(PreProcessedBlockPtr ppb, bool alsoSaveUnfoInfo, unsigned num2ReserveAfter = 0, bool notifySubs = false);
+    void addBlock(PreProcessedBlockPtr ppb, bool alsoSaveUnfoInfo, unsigned num2ReserveAfter = 0, bool notifySubs = false,
+                  bool trackRecentBlockTxHashes = false);
 
     /// Thread-safe.  Will attempt to undo the latest block that was previously added via a successfully completed call
     /// to addBlock().  This should be called if addBlock throws HeaderVerificationFailure. This function may throw
@@ -295,9 +296,10 @@ public:
     /// Caller must hold the returned ExclusiveLockGuard for as long as they use the reference otherwise bad things happen!
     std::pair<Mempool &, ExclusiveLockGuard> mutableMempool();
 
-    /// Returns true if txhash is in the mempool or in a recent block, false otherwise.
+    /// Returns true if txhash is in the mempool or in a recent block, false otherwise. Note that "recent block"
+    /// tracking is not always enabled, so a false result may not necessarily mean the txn is not in the latest block.
     /// Thread-safe (takes mempool shared lock and/or blocks lock internally).
-    bool isRecentlySeenTx(const TxHash &txhash) const;
+    bool isMaybeRecentlySeenTx(const TxHash &txhash) const;
 
     /// Thread-safe. Query db (but not mempool) for a UTXO, and return its info if found.  May throw on database error.
     /// (Does not take the blocks lock)

--- a/src/Util.h
+++ b/src/Util.h
@@ -1037,7 +1037,7 @@ protected:
 ///     Defer d1( [&]{ someUniqPtr.reset(); } );
 ///
 /// But the RAII version above is more explicit about what code goes with what cleanup.
-struct RAII : public Defer<> {
+struct RAII : Defer<> {
     /// initFunc called immediately, cleanupFunc called in this instance's destructor
     RAII(const VoidFunc & initFunc, const VoidFunc &cleanupFunc) : Defer(cleanupFunc) { if (initFunc) initFunc(); valid = bool(cleanupFunc); }
     /// initFunc called immediately, cleanupFunc called in this instance's destructor


### PR DESCRIPTION
- Requires that bitcoind be configured with ZMQ pubhashtx enabled, e.g. `-zmqpubhashtx=tcp://*:9332` (where 9332 here is any port).
- By default, even if bitcoind has this `pubhashtx` ZMQ notification enabled, Fulcrum will **not** use it _unless_ `zmq_allow_hashtx = true` is specified in the Fulcrum config file
  - This is because this ZMQ message is *very* spammy and eats cycles, and is not necessary for most uers.
- As such, this new feature is opt-in and is intended for server admins wishing to minimize mempool txn latency -> wallet clients.
  