### PR TITLE
Add http and https support

### DIFF
--- a/doc/fulcrum-example-config.conf
+++ b/doc/fulcrum-example-config.conf
@@ -628,7 +628,7 @@ rpcpassword = hunter1
 #
 #tor_wss_port = 50004
 
-# Tor HTTP port - 'tor_ws_port' - DEFAULT: Nothing
+# Tor HTTP port - 'tor_http_port' - DEFAULT: Nothing
 #
 # If set, we will advertise ourselves as living on the .onion tor_hostname above
 # and offering this port for incoming HTTP connections via Tor. At least one of
@@ -640,7 +640,7 @@ rpcpassword = hunter1
 #tor_http_port = 50005
 
 
-# Tor HTTPS port - 'tor_wss_port' - DEFAULT: Nothing
+# Tor HTTPS port - 'tor_https_port' - DEFAULT: Nothing
 #
 # If set, we will advertise ourselves as living on the .onion tor_hostname above
 # and offering this port for incoming HTTPS connections via Tor. At least one of

--- a/doc/fulcrum-example-config.conf
+++ b/doc/fulcrum-example-config.conf
@@ -168,6 +168,35 @@ rpcpassword = hunter1
 #wss = 0.0.0.0:50004
 
 
+# HTTP bind - 'http' - DEFAULT: disabled (no HTTP bind port)
+#
+# Specifies the IPv4 or IPv6 interface:port to bind to for the HTTP protocol
+# (http://) port. Typically on the Electron Cash network 50005 & 50006 are for
+# mainnet HTTP & HTTPS and 60005 & 60006 are for testnet HTTP & HTTPS, respectively.
+# If you wish to bind to multiple ports, you may specify this option multiple
+# times, once for each interface:port combination.
+#
+# You may specify either IPv4 or IPv6 interfaces.
+#
+#http = 0.0.0.0:50003
+
+
+# HTTPS bind - 'https' - DEFAULT: disabled (no HTTPS bind port)
+#
+# Specifies the IPv4 or IPv6 interface:port to bind to for the HTTPS protocol
+# (https://) port. Typically on the Electron Cash network 50005 & 50006 are for
+# mainnet HTTP & HTTPS and 60005 & 60006 are for testnet WS & HTTPS, respectively. If
+# you wish to bind to multiple ports, you may specify this option multiple
+# times, once for each interface:port combination.
+#
+# If you enable HTTPS you must also specify the 'cert' and 'key' configuration
+# parameters (see below).
+#
+# You may specify either IPv4 or IPv6 interfaces.
+#
+#https = 0.0.0.0:50004
+
+
 # SSL certificate - 'cert' - DEFAULT: None (required for SSL)
 #
 # Specifies the SSL certificate to use for all SSL ports. The certificate must be
@@ -208,6 +237,29 @@ rpcpassword = hunter1
 # also be specified.
 #
 #wss_key = /path/to/my-ca-signed-wss-privkey.pem
+
+
+# HTTPS-specific certificate - 'https_cert' - DEFAULT: None (recommended for HTTPS)
+#
+# Similar to `cert`, but will only be applied to `https` ports. This parameter
+# should be a CA-signed fullchain.pem file. This option is intended to allow HTTPS
+# ports to use a CA-signed certificate (required by web browsers), whereas
+# legacy Electrum Cash ports may want to continue to use self-signed
+# certificates. If this option is specified, `https_key` must also be specified.
+# If this option is missing, then HTTPS ports will just fall-back to using the
+# certificate specified by `cert`.
+#
+#https_cert = /path/to/my-ca-signed-https-fullchain.pem
+
+
+# HTTPS-specific private key - 'https_key' - DEFAULT: None (recommended for HTTPS)
+#
+# Similar parameter to `key`, but will only be applied to `https` ports. Specify a
+# private key PEM file to use for HTTPS. This key must go with the certificate
+# specified in `https_cert` above. If this option is specified, `https_cert` must
+# also be specified.
+#
+#https_key = /path/to/my-ca-signed-https-privkey.pem
 
 
 # Admin RPC bind - 'admin' - DEFAULT: None
@@ -442,6 +494,39 @@ rpcpassword = hunter1
 #
 #public_wss_port = 50004
 
+# Public HTTP port - 'public_http_port' - DEFAULT: The first 'http' port configured
+#
+# The server's public HTTP port. This, along with 'hostname' and the
+# various 'public_*_port' variables are announced to clients and to other servers
+# engaged in peer discovery. The default for this variable is to simply use the
+# first non-loopback HTTP port specified in the server configuration (if any). If
+# you are behind a firewall and doing some port remapping, then you definitely
+# want to set this option. This should be the public HTTP port as would be used
+# by the rest of the internet to connect to your server via an unencrypted HTTP
+# protocol (http://) connection. You may also set this option to 0 to disable
+# reporting any HTTP port. See also: `http`, `tor_http_port`, `upnp`.
+#
+#public_http_port = 50005
+
+# Public HTTPS port - 'public_https_port' - DEFAULT: The first 'https' port configured
+#
+# The server's public HTTPS port. This, along with 'hostname'
+# and the various 'public_*_port' variables are announced to clients and to other
+# servers engaged in peer discovery. The default for this variable is to simply
+# use the first non-loopback HTTPS port specified in the server configuration (if
+# any). If you are behind a firewall and doing some port remapping, then you
+# definitely want to set this option. This should be the public HTTPS port as
+# would be used by the rest of the internet to connect to your server via an
+# encrypted HTTP protocol (https://) connection. You may also set this option
+# to 0 to disable reporting any HTTPS port. See also: `https`, `tor_https_port`,
+# `upnp`.
+#
+#public_https_port = 50006
+
+# HTTP CORS domain - 'http_cors_domain' - DEFAULT: None
+# The HTTP CORS domain to be sent to browser clients. If not specified, browser
+# clients will not be able to connect.
+# http_cors_domain = *
 
 # Peer discovery - 'peering' - DEFAULT: true
 #
@@ -542,6 +627,29 @@ rpcpassword = hunter1
 # This option may not be specified multiple times.
 #
 #tor_wss_port = 50004
+
+# Tor HTTP port - 'tor_ws_port' - DEFAULT: Nothing
+#
+# If set, we will advertise ourselves as living on the .onion tor_hostname above
+# and offering this port for incoming HTTP connections via Tor. At least one of
+# the various tor_*_port variables must be set (along with tor_hostname) in
+# order to announce this server via Tor.
+#
+# This option may not be specified multiple times.
+#
+#tor_http_port = 50005
+
+
+# Tor HTTPS port - 'tor_wss_port' - DEFAULT: Nothing
+#
+# If set, we will advertise ourselves as living on the .onion tor_hostname above
+# and offering this port for incoming HTTPS connections via Tor. At least one of
+# the various tor_*_port variables must be set (along with tor_hostname) in
+# order to announce this server via Tor.
+#
+# This option may not be specified multiple times.
+#
+#tor_https_port = 50006
 
 
 # Tor proxy to use for outbound connections - 'tor_proxy, tor_user, tor_pass'

--- a/doc/fulcrum-quick-config.conf
+++ b/doc/fulcrum-quick-config.conf
@@ -54,6 +54,15 @@ ws = 0.0.0.0:50003
 # presence of this variable requires key= and cert= both be specified.
 wss = 0.0.0.0:50004
 
+# *RECOMMENDED* - HTTP bind - 'http' - DEFAULT: Nothing, Specifies the IPv4 or IPv6
+# interface:port to bind to for HTTP protocol support (http://).
+http = 0.0.0.0:50005
+
+# *RECOMMENDED* - HTTPS bind - 'https' - DEFAULT: Nothing, Specifies the IPv4 or
+# IPv6 interface:port to bind to for HTTP Secure protocol support (https://). The
+# presence of this variable requires key= and cert= both be specified.
+https = 0.0.0.0:50006
+
 # Enable UPnP support - 'upnp' - DEFAULT: false (disabled). Useful for servers
 # behind NAT firewalls. Specifies that Fulcrum should contact your router
 # ask it to open up ports for all specified (non-looopback) tcp/ssl/ws/wss
@@ -75,6 +84,12 @@ key = /path/to/server-key.pem
 
 # WSS-specific private key - 'wss_key' - DEFAULT: None
 #wss_key = /path/to/my-ca-signed-wss-privkey.pem
+
+# HTTPS-specific cert. - 'https_cert' - DEFAULT: None
+#https_cert = /path/to/my-ca-signed-https-fullchain.pem
+
+# HTTPS-specific private key - 'https_key' - DEFAULT: None
+#https_key = /path/to/my-ca-signed-https-privkey.pem
 
 # Public hostname - 'hostname' - It is highly recommended you set this correctly
 # if you are interested in having your server peer with other servers --
@@ -102,6 +117,16 @@ announce = true
 
 # Public WSS port - 'public_wss_port' - DEFAULT: The first 'wss' port configured
 #public_wss_port = 50004
+
+# Public HTTP port - 'public_http_port' - DEFAULT: The first 'http' port configured
+#public_http_port = 50005
+
+# Public HTTPS port - 'public_https_port' - DEFAULT: The first 'https' port configured
+#
+#public_https_port = 50006
+
+# HTTP CORS domain - 'http_cors_domain' - DEFAULT: None
+# http_cors_domain = *
 
 # Admin RPC bind - 'admin' - DEFAULT: None -- *REQUIRED* to use "FulcrumAdmin"
 admin = 8000  # <-- 1.2.3.4:8000 notation also accepted here

--- a/doc/unix-man-page.md
+++ b/doc/unix-man-page.md
@@ -52,6 +52,15 @@ Once the server finishes synching it will behave like an ElectronX/ElectrumX ser
 -W, --wss <interface:port>
 :   Specify an <interface:port> on which to listen for Web Socket Secure connections (encrypted, wss://). Note that if this option is specified, then the --cert and --key options (or alternatively, the --wss-cert and --wss-key options) need to also be specified otherwise the app will refuse to run. This option may be specified more than once to bind to multiple interfaces and/or ports. Suggested values for port: 50004 on mainnet and 60004 on testnet.
 
+--http <interface:port>
+:   Specify an <interface:port> on which to listen for HTTP connections (unencrypted, http://). This option may be specified more than once to bind to multiple interfaces and/or ports. Suggested values for port: 50005 on mainnet and 60005 on testnet.
+
+--https <interface:port>
+:   Specify an <interface:port> on which to listen for HTTP Secure connections (encrypted, https://). Note that if this option is specified, then the --cert and --key options (or alternatively, the --https-cert and --https-key options) need to also be specified otherwise the app will refuse to run. This option may be specified more than once to bind to multiple interfaces and/or ports. Suggested values for port: 50006 on mainnet and 60006 on testnet.
+
+--http-cors-domain <value>
+:   Domain from which to accept cross origin requests. `*` allows all origins. If not specified, browser requests will never work.
+
 -c, --cert <crtfile>
 :   Specify a PEM file to use as the server's SSL certificate.  This option is required if the -s/--ssl and/or the -W/--wss options appear at all on the command-line.  The file should contain either a single valid self-signed certificate or the full certificate chain if using CA-signed certificates.
 

--- a/src/AbstractConnection.cpp
+++ b/src/AbstractConnection.cpp
@@ -40,8 +40,8 @@ QString AbstractConnection::prettyName(bool dontTouchSocket, bool showId, Anonym
 {
     const bool anon = anonip == AnonymizeIP::Yes;
     const QString type = socket && !dontTouchSocket
-                         ? (isSsl() ? (isWebSocket() ? QStringLiteral("WSS") : QStringLiteral("SSL"))
-                                    : (isWebSocket() ? QStringLiteral("WS")  : QStringLiteral("TCP")))
+                         ? (isSsl() ? (isWebSocket() ? QStringLiteral("WSS") : (isHttp() ? QStringLiteral("HTTPS") : QStringLiteral("SSL")))
+                                    : (isWebSocket() ? QStringLiteral("WS")  : (isHttp() ? QStringLiteral("HTTP") : QStringLiteral("TCP"))))
                          : QStringLiteral("(NoSocket)");
     QString ip, port, idStr;
     if (!anon && socket && !dontTouchSocket && !socket->peerAddress().isNull())
@@ -109,6 +109,11 @@ bool AbstractConnection::isSsl() const
 }
 
 bool AbstractConnection::isWebSocket() const
+{
+    return false;
+}
+
+bool AbstractConnection::isHttp() const
 {
     return false;
 }

--- a/src/AbstractConnection.h
+++ b/src/AbstractConnection.h
@@ -71,6 +71,8 @@ public:
     /// Default implementation returns false.  If the connection is an ElectrumConnection (derived class), it may
     /// return true if it is being handled via the WebSocket::Wrapper class.
     virtual bool isWebSocket() const;
+    /// Default implementation returns false.  If the connection is an HttpClient (derived class), it returns true.
+    virtual bool isHttp() const;
 
 signals:
     void lostConnection(AbstractConnection *);

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -109,14 +109,19 @@ QVariantMap Options::toMap() const
     // /interfaces
 
     {
-        const auto & [certInfo, wssCertInfo] = certs.load();
+        const auto & [certInfo, wssCertInfo, httpsCertInfo] = certs.load();
         m["cert"] = certInfo.file;
         m["key"] = certInfo.keyFile;
         if (wssCertInfo.has_value()) {
             m["wss-cert"] = wssCertInfo->file;
             m["wss-key"] = wssCertInfo->keyFile;
         }
+        if (wssCertInfo.has_value()) {
+            m["https-cert"] = httpsCertInfo->file;
+            m["https-key"] = httpsCertInfo->keyFile;
+        }
     }
+    m["httpCorsDomain"] = httpCorsDomain;
     m["bitcoind"] = QString("%1:%2").arg(bdRPCInfo.hostPort.first, QString::number(bdRPCInfo.hostPort.second));
     m["bitcoind-tls"] = bdRPCInfo.tls;
     m["hasIPv6 listener"] = hasIPv6Listener;
@@ -140,6 +145,8 @@ QVariantMap Options::toMap() const
     m["public_ssl_port"] = publicSsl.has_value() ? QVariant(*publicSsl) : QVariant();
     m["public_ws_port"] = publicWs.has_value() ? QVariant(*publicWs) : QVariant();
     m["public_wss_port"] = publicWss.has_value() ? QVariant(*publicWss) : QVariant();
+    m["public_http_port"] = publicHttp.has_value() ? QVariant(*publicHttp) : QVariant();
+    m["public_https_port"] = publicHttps.has_value() ? QVariant(*publicHttps) : QVariant();
     m["max_clients_per_ip"] = maxClientsPerIP;
     l.clear();
     for (const auto & sn : subnetsExcludedFromPerIPLimits)
@@ -156,6 +163,8 @@ QVariantMap Options::toMap() const
     m["tor_ssl_port"] = torSsl.has_value() ? QVariant(*torSsl) : QVariant();
     m["tor_ws_port"] = torWs.has_value() ? QVariant(*torWs) : QVariant();
     m["tor_wss_port"] = torWss.has_value() ? QVariant(*torWss) : QVariant();
+    m["tor_http_port"] = torHttp.has_value() ? QVariant(*torHttp) : QVariant();
+    m["tor_https_port"] = torHttps.has_value() ? QVariant(*torHttps) : QVariant();
     m["tor_proxy"] = QString("%1:%2").arg(torProxy.first.toString()).arg(torProxy.second);
     m["tor_user"] = torUser.isNull() ? QVariant() : QVariant("<hidden>");
     m["tor_pass"] = torPass.isNull() ? QVariant() : QVariant("<hidden>");

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -116,7 +116,7 @@ QVariantMap Options::toMap() const
             m["wss-cert"] = wssCertInfo->file;
             m["wss-key"] = wssCertInfo->keyFile;
         }
-        if (wssCertInfo.has_value()) {
+        if (httpsCertInfo.has_value()) {
             m["https-cert"] = httpsCertInfo->file;
             m["https-key"] = httpsCertInfo->keyFile;
         }

--- a/src/Options.h
+++ b/src/Options.h
@@ -52,7 +52,7 @@ public:
     /// output the configured options to the /stats output JSON, for example.
     QVariantMap toMap() const;
 
-    static constexpr quint16 DEFAULT_PORT_TCP = 50001, DEFAULT_PORT_SSL = 50002, DEFAULT_PORT_WS = 50003, DEFAULT_PORT_WSS = 50004;
+    static constexpr quint16 DEFAULT_PORT_TCP = 50001, DEFAULT_PORT_SSL = 50002, DEFAULT_PORT_WS = 50003, DEFAULT_PORT_WSS = 50004, DEFAULT_PORT_HTTP = 50005, DEFAULT_PORT_HTTPS = 50006;
 
     std::atomic_bool verboseDebug =
 #ifdef QT_DEBUG
@@ -72,7 +72,9 @@ public:
     QList<Interface> interfaces, ///< TCP interfaces to use for binding, defaults to 0.0.0.0 DEFAULT_PORT_TCP
                      sslInterfaces,  ///< SSL interfaces to use for binding SSL ports. Defaults to nothing.
                      wsInterfaces,   ///< Web Socket (WS) interfaces. Defaults to nothing.
-                     wssInterfaces;  ///< Web Socket Secure (WSS) interfaces. Defaults to nothing.
+                     wssInterfaces,  ///< Web Socket Secure (WSS) interfaces. Defaults to nothing.
+                     httpInterfaces, ///< HTTP interfaces. Defaults to nothing.
+                     httpsInterfaces;///< HTTPS interfaces. Defaults to nothing.
     QList<Interface> statsInterfaces; ///< 'stats' server, defaults to empty (no stats server)
     QList<Interface> adminInterfaces; ///< the admin server, defaults to empty (no admin RPC)
     struct CertInfo {
@@ -87,7 +89,10 @@ public:
         CertInfo certInfo;
         /// if valid, then the user specified --wss-cert and --wss-key on CLI or in config, and these are those.
         std::optional<CertInfo> wssCertInfo;
+        /// if valid, then the user specified --https-cert and --https-key on CLI or in config, and these are those.
+        std::optional<CertInfo> httpsCertInfo;
     };
+    QString httpCorsDomain; ///< if set, the value to use for Access-Control-Allow-Origin header on HTTP(S) responses
     AtomicStruct<Certs> certs; ///< gets writeen-to at App init and also by the SSLCertMonitor
     BitcoinD_RPCInfo bdRPCInfo; ///< contains: rpcs user, rpc pass, host, port, and usesTls (see BitcoinD_RPCInfo.h)
     QString datadir; ///< The directory to store the database. It exists and has appropriate permissions (otherwise the app would have quit on startup).
@@ -116,10 +121,14 @@ public:
     std::optional<quint16> publicSsl;   ///< corresponds to public_ssl_port in server config -- if unspecified will default to the first SSL interface, if !has_value, it will not be announced
     std::optional<quint16> publicWs;   ///< corresponds to public_ws_port in server config -- if unspecified will default to the first WS interface, if !has_value, it will not be announced
     std::optional<quint16> publicWss;   ///< corresponds to public_wss_port in server config -- if unspecified will default to the first WSS interface, if !has_value, it will not be announced
+    std::optional<quint16> publicHttp;   ///< corresponds to public_http_port in server config -- if unspecified will default to the first HTTP interface, if !has_value, it will not be announced
+    std::optional<quint16> publicHttps;   ///< corresponds to public_http_port in server config -- if unspecified will default to the first HTTPS interface, if !has_value, it will not be announced
     std::optional<quint16> torTcp;   ///< corresponds to tor_tcp_port in server config -- if unspecified will not announce tcp on tor route.
     std::optional<quint16> torSsl;   ///< corresponds to tor_ssl_port in server config -- if unspecified will not announce ssl on tor route.
     std::optional<quint16> torWs;   ///< corresponds to tor_ws_port in server config -- if unspecified will not announce ws on tor route.
     std::optional<quint16> torWss;   ///< corresponds to tor_wss_port in server config -- if unspecified will not announce wss on tor route.
+    std::optional<quint16> torHttp;   ///< corresponds to tor_http_port in server config -- if unspecified will not announce http on tor route.
+    std::optional<quint16> torHttps;   ///< corresponds to tor_https_port in server config -- if unspecified will not announce https on tor route.
 
     // Max clients per IP related
     static constexpr int defaultMaxClientsPerIP = 12;

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -717,7 +717,7 @@ namespace RPC {
         // TODO: In the non-WebSocket case, scanning for '\n' may be slow for large loads.
         // Also TODO: This should have some upper bound on how many times it loops and come back later if too much data
         // is available.
-        while (!isBad() && socket && (ws ? ws->messagesAvailable() > 0 : socket->canReadLine())) {
+        while (!isBad() && socket && (ws ? ws->messagesAvailable() > 0 : (isHttp() ? (socket->canReadLine() || socket->bytesAvailable() > 0) : socket->canReadLine()))) {
             // check if paused -- we may get paused inside processJson below
             if (readPaused) {
                 skippedOnReadyRead = true;

--- a/src/SSLCertMonitor.cpp
+++ b/src/SSLCertMonitor.cpp
@@ -157,7 +157,7 @@ Options::Certs SSLCertMonitor::readCerts() const
         certs.wssCertInfo = SSLCertMonitor::makeCertInfo(this, wssCert, wssKey);
     }
     if (!httpsCert.isEmpty()) {
-        if (httpsKey.isEmpty()) throw InternalError("Internal Error: wss-key is empty"); // sanity check
+        if (httpsKey.isEmpty()) throw InternalError("Internal Error: https-key is empty"); // sanity check
         certs.httpsCertInfo = SSLCertMonitor::makeCertInfo(this, httpsCert, httpsKey);
     }
     return certs;

--- a/src/SSLCertMonitor.cpp
+++ b/src/SSLCertMonitor.cpp
@@ -38,17 +38,25 @@ SSLCertMonitor::SSLCertMonitor(std::shared_ptr<Options> options_, QObject *paren
 }
 
 void SSLCertMonitor::start(const QString &certFile, const QString &keyFile,
-                           const QString &wssCertFile, const QString &wssKeyFile)
+                           const QString &wssCertFile, const QString &wssKeyFile,
+                           const QString &httpsCertFile, const QString &httpsKeyFile)
 {
     cert = certFile;
     key = keyFile;
     wssCert = wssCertFile;
     wssKey = wssKeyFile;
+    httpsCert = httpsCertFile;
+    httpsKey = httpsKeyFile;
 
     if (cert.isEmpty() && !wssCert.isEmpty()) {
         // copy over wssCert/wssKey to cert/key, clear wssCert/wssKey
         cert = wssCert;  wssCert.clear();
         key  = wssKey;   wssKey.clear();
+    }
+    if (cert.isEmpty() && !httpsCert.isEmpty()) {
+        // copy over httpsCert/httpsKey to cert/key, clear httpsCert/httpsKey
+        cert = httpsCert;  httpsCert.clear();
+        key  = httpsKey;   httpsKey.clear();
     }
     // sanity check
     if (cert.isEmpty() || key.isEmpty()) throw InternalError("Internal Error: cert and/or key is empty");
@@ -64,6 +72,10 @@ void SSLCertMonitor::start(const QString &certFile, const QString &keyFile,
     if (!wssCert.isEmpty() && !watcher->files().contains(wssCert)) {
         watcher->addPath(wssCert);
         watchedFiles.append(wssCert);
+    }
+    if (!httpsCert.isEmpty() && !watcher->files().contains(httpsCert)) {
+        watcher->addPath(httpsCert);
+        watchedFiles.append(httpsCert);
     }
     Util::AsyncOnObject(this, [this]{
         DebugM("SSLCertMonitor: Watching files [", watchedFiles.join(", "), "]");
@@ -123,7 +135,7 @@ void SSLCertMonitor::on_fileChanged(const QString &path)
 
         try {
             // this re-reads all the certs, if it doesn't throw they were read and stored successfully
-            start(cert, key, wssCert, wssKey);
+            start(cert, key, wssCert, wssKey, httpsCert, httpsKey);
             emit certInfoChanged();
             return false; // don't keep trying, done
         } catch (const InternalError &e) {
@@ -143,6 +155,10 @@ Options::Certs SSLCertMonitor::readCerts() const
     if (!wssCert.isEmpty()) {
         if (wssKey.isEmpty()) throw InternalError("Internal Error: wss-key is empty"); // sanity check
         certs.wssCertInfo = SSLCertMonitor::makeCertInfo(this, wssCert, wssKey);
+    }
+    if (!httpsCert.isEmpty()) {
+        if (httpsKey.isEmpty()) throw InternalError("Internal Error: wss-key is empty"); // sanity check
+        certs.httpsCertInfo = SSLCertMonitor::makeCertInfo(this, httpsCert, httpsKey);
     }
     return certs;
 }

--- a/src/SSLCertMonitor.h
+++ b/src/SSLCertMonitor.h
@@ -41,7 +41,7 @@ public:
 
     /// Actually starts the monitoring task and also populates the options->certs object with valid certs.
     /// May throw on error.
-    void start(const QString &certFile, const QString &keyFile, const QString &wssCertFile, const QString &wssKeyFile);
+    void start(const QString &certFile, const QString &keyFile, const QString &wssCertFile, const QString &wssKeyFile, const QString &httpsCertFile, const QString &httpsKeyFile);
 
 signals:
     /// This is emitted when the (valid) cert files on disk have changed and been re-read by this class.
@@ -53,7 +53,7 @@ private slots:
 
 private:
     std::shared_ptr<Options> options;
-    QString cert, key, wssCert, wssKey;
+    QString cert, key, wssCert, wssKey, httpsCert, httpsKey;
     QFileSystemWatcher *watcher = nullptr;
     QStringList watchedFiles;
 

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -3580,11 +3580,11 @@ void HttpClient::on_readyRead()
                 for (auto it = vmap.begin(); it != vmap.end(); ++it) {
                     // save header
                     req.header[it.key()] = it.value().toString();
-                    if (it.key() == "server.version") {
+                    if (it.key() == "Server-Version") {
                         try {
                             auto versionList = Json::parseUtf8(it.value().toString().toUtf8(), Json::ParseOption::RequireArray).toList();
                             auto pver = setServerVersion(versionList, false);
-                            response.headerExtra.append(QString("server.version: [\"%1\", \"%2\"]\r\n").arg(ServerMisc::AppSubVersion).arg(pver.toString()).toUtf8());
+                            response.headerExtra.append(QString("Server-Version: [\"%1\", \"%2\"]\r\n").arg(ServerMisc::AppSubVersion).arg(pver.toString()).toUtf8());
                         } catch (const std::exception &e) {
                             response.status = 400;
                             response.statusText = e.what();
@@ -3607,7 +3607,7 @@ void HttpClient::on_readyRead()
                 if (req.method == SimpleHttpServer::Method::POST) {
                     req.response.contentType = "application/json; charset=utf-8";
                 } else if (req.method == SimpleHttpServer::Method::OPTIONS) {
-                    response.headerExtra.append(QString("Access-Control-Allow-Methods: POST\r\nAccess-Control-Allow-Headers: content-type, server.version\r\n").toUtf8());
+                    response.headerExtra.append(QString("Access-Control-Allow-Methods: POST\r\nAccess-Control-Allow-Headers: content-type, Server-Version\r\n").toUtf8());
                     response.data = response.statusText;
                 }
                 // setup header

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -743,6 +743,13 @@ protected:
     QByteArray wrapForSend(QByteArray &&) override;
     void on_readyRead() override;
     void cleanupForNextRequest();
+
+    QMap<QString, QString> reqHeader;
+    QString reqLoc;
+    QString reqMeth;
+    QString reqVer;
+    qint64 respLen = 0;
+    QByteArray pendingResponseHeader;
 };
 
 namespace detail {

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -558,6 +558,9 @@ public:
     /// Overides ServerBase -- re-sets the SSL config (sometimes WSS uses a different config from regular SSL ports).
     /// Do not call this after the server has already been started.
     void setUsesWebSockets(bool b) override;
+    /// Overrides ServerBase -- re-sets the SSL config (HTTPS may use a different config from regular SSL ports).
+    /// Do not call this after the server has already been started.
+    void setUsesHttp(bool b) override;
 
 public slots:
     /// Normally called from c'tor, but may be called as a result of a connection to SSLCertMonitor's certInfoChanged()


### PR DESCRIPTION
This PR adds HTTP and HTTPS protocol support.

I would appreciate the review and consideration for mainline inclusion.

While the connections are short lived, modern browsers do not immediately close them and there is a window to send several requests throughout the connection lifetime. Most common example is cors preflight OPTIONS check followed by POST request. This, however, is still not enough for subscriptions to work, so they are disabled.

Docker image mainnetpat/fulcrum-http:latest
Deployed behind nginx: https://fulcrum.pat.mn, wss://fulcrum.pat.mn

PS
Server version negotiation is optional and is done by inclusion of `Server-Version` header, which is structured the same way the `server.version` rpc call is made and returns the result of the call in the response header with the same name.

```bash
$ curl -X POST -d '{"id":1, "jsonrpc":"2.0","method":"blockchain.headers.get_tip", "params": []}' -H "Content-Type: application/json" -H "Server-Version: [\"Curl\", [\"1.3.0\", \"1.6.0\"]]"" https://fulcrum.pat.mn -v
> POST / HTTP/1.1
> Host: fulcrum.pat.mn
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Type: application/json
> Server-Version: ["Curl", ["1.3.0", "1.6.0"]]
> Content-Length: 77
> 
* upload completely sent off: 77 bytes
< HTTP/1.1 200 Success
< Server: nginx/1.24.0 (Ubuntu)
< Date: Fri, 28 Nov 2025 19:08:24 GMT
< Content-Type: application/json; charset=utf-8
< Content-Length: 220
< Connection: keep-alive
< Cache-Control: no-cache
< Server-Version: ["Fulcrum 2.1.0", "1.6"]
< Access-Control-Allow-Origin: *
< 
* Connection #0 to host fulcrum.pat.mn left intact
{"id":1,"jsonrpc":"2.0","result":{"height":927052,"hex":"00602834f3c48f0789ad516d6cc89b3c5ebe7a449db0e80a75e4260100000000000000004644f6426b53828a53d3240d9dff601569e0427284634820f8a273b0c3d9233817f329699e450118d131acf1"}}
```