### PR TITLE
doc: update Bitcoin Core RPC scaling note

### DIFF
--- a/doc/fulcrum-example-config.conf
+++ b/doc/fulcrum-example-config.conf
@@ -577,10 +577,8 @@ rpcpassword = hunter1
 # -rpcthreads option in bitcoind) may yield better parallelism during initial DB
 # synch as well as better performance for your clients. This number should not
 # exceed the number of cores in your system, however, as performance may suffer
-# in that case. Note that Bitcoin Core doesn't parallelize very well on its
-# `getblocks` call due to the way it holds a global lock throughout the entire
-# call, so if you are on BTC, your mileage may vary with how much extra
-# performance you can get from more simultaneous clients specified here.
+# in that case. Note that Bitcoin Core didn't parallelize RPC `getblock` calls
+# very well before v25.
 #
 #bitcoind_clients = 3
 


### PR DESCRIPTION
**Problem:** The `bitcoind_clients` sample config still described a stale global-lock bottleneck for parallel block downloads. 
Bitcoin Core v25 improved this via bitcoin/bitcoin#26308.
Later bitcoin/bitcoin#26415 improved raw-block `getblock` further.

**Fix:** Update the note to reflect that Bitcoin Core handles parallel RPC `getblock` calls better since v25.